### PR TITLE
[Feat] 로그인 구현

### DIFF
--- a/src/main/java/com/example/demo/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalErrorCode.java
@@ -31,6 +31,7 @@ public enum GlobalErrorCode {
   // 400 Bad Request
   NOT_VALID_PASSWORD(HttpStatus.BAD_REQUEST, "40001", "비밀번호는 영문, 숫자, 특수문자를 포함한 9~16글자여야 합니다."),
   MALFORMED_TOKEN(HttpStatus.BAD_REQUEST, "40002", "토큰의 형식이 올바르지 않습니다."),
+  PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "40003", "비밀번호가 일치하지 않습니다."),
 
   // 401 Unauthorized
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "40101", "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/example/demo/member/controller/AuthController.java
+++ b/src/main/java/com/example/demo/member/controller/AuthController.java
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.demo.global.exception.GlobalErrorCode;
 import com.example.demo.global.response.BaseResponse;
+import com.example.demo.member.dto.request.LoginRequestDto;
 import com.example.demo.member.dto.request.SignUpMemberRequestDto;
+import com.example.demo.member.dto.response.LoginResponseDto;
 import com.example.demo.member.facade.AuthFacade;
 
 import lombok.RequiredArgsConstructor;
@@ -27,5 +29,12 @@ public class AuthController {
     authFacade.signUpMember(requestDto);
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(BaseResponse.onSuccess(GlobalErrorCode.CREATED, null));
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<BaseResponse<LoginResponseDto>> login(
+      @RequestBody LoginRequestDto requestDto) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(BaseResponse.onSuccess(GlobalErrorCode.OK, authFacade.login(requestDto)));
   }
 }

--- a/src/main/java/com/example/demo/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/example/demo/member/dto/request/LoginRequestDto.java
@@ -1,0 +1,3 @@
+package com.example.demo.member.dto.request;
+
+public record LoginRequestDto(String email, String password) {}

--- a/src/main/java/com/example/demo/member/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/example/demo/member/dto/response/LoginResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.demo.member.dto.response;
+
+import com.example.demo.member.entity.Member;
+
+import lombok.Builder;
+
+@Builder
+public record LoginResponseDto(
+    Long memberId, String nickname, String profileImage, String accessToken, String refreshToken) {
+
+  public static LoginResponseDto from(Member member, String accessToken, String refreshToken) {
+    return LoginResponseDto.builder()
+        .memberId(member.getId())
+        .nickname(member.getNickname())
+        .profileImage(member.getProfileImage())
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .build();
+  }
+}

--- a/src/main/java/com/example/demo/member/entity/repository/MemberRepository.java
+++ b/src/main/java/com/example/demo/member/entity/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package com.example.demo.member.entity.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.demo.member.entity.Member;
@@ -7,4 +9,6 @@ import com.example.demo.member.entity.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Boolean existsByEmail(String email);
+
+  Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/example/demo/member/facade/AuthFacade.java
+++ b/src/main/java/com/example/demo/member/facade/AuthFacade.java
@@ -2,7 +2,10 @@ package com.example.demo.member.facade;
 
 import org.springframework.stereotype.Component;
 
+import com.example.demo.member.dto.request.LoginRequestDto;
 import com.example.demo.member.dto.request.SignUpMemberRequestDto;
+import com.example.demo.member.dto.response.LoginResponseDto;
+import com.example.demo.member.entity.Member;
 import com.example.demo.member.service.command.AuthCommandService;
 import com.example.demo.member.service.query.MemberQueryService;
 
@@ -25,5 +28,12 @@ public class AuthFacade {
     memberQueryService.isValidEmail(requestDto.email());
 
     authCommandService.signUpMember(requestDto);
+  }
+
+  public LoginResponseDto login(LoginRequestDto requestDto) {
+
+    Member member = memberQueryService.getMemberByEmail(requestDto.email());
+
+    return authCommandService.login(member, requestDto.password());
   }
 }

--- a/src/main/java/com/example/demo/member/service/query/MemberQueryService.java
+++ b/src/main/java/com/example/demo/member/service/query/MemberQueryService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.demo.global.exception.GlobalErrorCode;
 import com.example.demo.global.exception.custom.MemberException;
+import com.example.demo.member.entity.Member;
 import com.example.demo.member.entity.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -25,5 +26,18 @@ public class MemberQueryService {
     if (memberRepository.existsByEmail(email)) {
       throw new MemberException(GlobalErrorCode.DUPLICATE_EMAIL);
     }
+  }
+
+  /**
+   * 주어진 이메일로 회원을 조회합니다.
+   *
+   * @param email 조회할 회원의 이메일
+   * @return 조회된 {@link Member} 엔티티
+   * @throws MemberException 해당 이메일로 회원을 찾을 수 없을 경우
+   */
+  public Member getMemberByEmail(String email) {
+    return memberRepository
+        .findByEmail(email)
+        .orElseThrow(() -> new MemberException(GlobalErrorCode.MEMBER_NOT_FOUND));
   }
 }

--- a/src/test/java/com/example/demo/Member/MemberTestConst.java
+++ b/src/test/java/com/example/demo/Member/MemberTestConst.java
@@ -1,10 +1,14 @@
 package com.example.demo.Member;
 
 public enum MemberTestConst {
+  TEST_ID("1"),
   TEST_EMAIL("test@example.com"),
   TEST_PASSWORD("Test1234!@#$"),
   TEST_NICKNAME("testUser"),
-  TEST_PROFILE_IMAGE("profile.jpg");
+  TEST_PROFILE_IMAGE("profile.jpg"),
+  TEST_ACCESS_TOKEN("testAccessToken"),
+  TEST_REFRESH_TOKEN("testRefreshToken"),
+  ;
 
   private final String value;
 


### PR DESCRIPTION
# 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# ❗️ 관련 이슈 링크
Close #9 

# 📌 개요
- 로그인 기능을 구현하여 이메일과 비밀번호를 통해 회원정보와 토큰을 받아옵니다.
- RESTful API로 '/api/auth/login' 엔드포인트를 추가하였습니다.

# 🔁 변경 사항
1. **AuthController**
   - `POST /api/auth/login` 엔드포인트 추가.

2. **AuthCommandService**
   - `login` 메서드 구현: 비밀번호 검증 후 토큰 생성 및 `LoginResponseDto` 반환.

3. **MemberQueryService**
   - `getMemberByEmail` 메서드 추가: 이메일로 회원 조회.

# 👀 기타 더 이야기해볼 점

![2025-02-26 21;15;56](https://github.com/user-attachments/assets/6cb02ef6-027f-4f50-81cc-8e17265d9d2d)
![2025-02-26 20;59;14](https://github.com/user-attachments/assets/d1ccedaa-1766-45d2-b8ad-4a2accdec79c)
![2025-02-26 21;10;24](https://github.com/user-attachments/assets/0129bc5f-f8ed-496c-8b99-2e077f0aa146)


# ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.