### PR TITLE
[Feat] : 토큰 검증 및 블랙리스트 처리 구현

### DIFF
--- a/src/main/java/com/example/demo/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalErrorCode.java
@@ -32,6 +32,7 @@ public enum GlobalErrorCode {
   NOT_VALID_PASSWORD(HttpStatus.BAD_REQUEST, "40001", "비밀번호는 영문, 숫자, 특수문자를 포함한 9~16글자여야 합니다."),
   MALFORMED_TOKEN(HttpStatus.BAD_REQUEST, "40002", "토큰의 형식이 올바르지 않습니다."),
   PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "40003", "비밀번호가 일치하지 않습니다."),
+  ALREADY_BLACKLIST_TOKEN(HttpStatus.BAD_REQUEST, "40004", "이미 블랙리스트에 존재합니다."),
 
   // 401 Unauthorized
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "40101", "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/example/demo/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalErrorCode.java
@@ -37,6 +37,7 @@ public enum GlobalErrorCode {
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "40101", "유효하지 않은 토큰입니다."),
   AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "40102", "인증이 필요합니다."),
   TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "40103", "토큰의 유효기간이 지났습니다."),
+  REFRESH_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "40104", "토큰이 일치하지 않습니다."),
 
   // 403 Forbidden
   ACCESS_DENIED(HttpStatus.FORBIDDEN, "40301", "권한이 없습니다."),

--- a/src/main/java/com/example/demo/global/security/provider/JwtProvider.java
+++ b/src/main/java/com/example/demo/global/security/provider/JwtProvider.java
@@ -101,7 +101,6 @@ public class JwtProvider {
     }
   }
 
-  /** 쿠키에서 refreshToken 추출 */
   public Optional<String> extractRefreshToken(HttpServletRequest request) {
     if (request.getCookies() == null) {
       return Optional.empty();

--- a/src/main/java/com/example/demo/member/entity/Member.java
+++ b/src/main/java/com/example/demo/member/entity/Member.java
@@ -2,10 +2,7 @@ package com.example.demo.member.entity;
 
 import jakarta.persistence.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "member")
@@ -38,6 +35,10 @@ public class Member {
 
   @Enumerated(EnumType.STRING)
   private Tier tier;
+
+  @Column(name = "refresh_token")
+  @Setter
+  private String refreshToken;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "member_role")

--- a/src/main/java/com/example/demo/member/entity/RefreshTokenBlackList.java
+++ b/src/main/java/com/example/demo/member/entity/RefreshTokenBlackList.java
@@ -1,0 +1,33 @@
+package com.example.demo.member.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refresh_token_black_list")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshTokenBlackList {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "refresh_token", nullable = false, unique = true)
+  private String refreshToken;
+
+  @Column(name = "expired_at", nullable = false)
+  private LocalDateTime expiredAt;
+
+  public static RefreshTokenBlackList of(String refreshToken, LocalDateTime expiredAt) {
+    return RefreshTokenBlackList.builder().refreshToken(refreshToken).expiredAt(expiredAt).build();
+  }
+}

--- a/src/main/java/com/example/demo/member/entity/repository/RefreshTokenBlackListRepository.java
+++ b/src/main/java/com/example/demo/member/entity/repository/RefreshTokenBlackListRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.member.entity.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.demo.member.entity.RefreshTokenBlackList;
+
+public interface RefreshTokenBlackListRepository
+    extends JpaRepository<RefreshTokenBlackList, Long> {
+
+  boolean existsByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/example/demo/member/facade/AuthFacade.java
+++ b/src/main/java/com/example/demo/member/facade/AuthFacade.java
@@ -10,6 +10,7 @@ import com.example.demo.member.dto.response.LoginWithRefreshResponseDto;
 import com.example.demo.member.dto.response.RefreshResponseDto;
 import com.example.demo.member.entity.Member;
 import com.example.demo.member.service.command.AuthCommandService;
+import com.example.demo.member.service.query.AuthQueryService;
 import com.example.demo.member.service.query.MemberQueryService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,12 +20,14 @@ import lombok.RequiredArgsConstructor;
 public class AuthFacade {
 
   private final AuthCommandService authCommandService;
+  private final AuthQueryService authQueryService;
   private final MemberQueryService memberQueryService;
 
   /**
    * 새로운 회원을 등록합니다.
    *
    * @param requestDto 회원가입 요청 데이터
+   * @return
    */
   public void signUpMember(SignUpMemberRequestDto requestDto) {
 
@@ -33,6 +36,12 @@ public class AuthFacade {
     authCommandService.signUpMember(requestDto);
   }
 
+  /**
+   * 이메일과 비밀번호를 통해 로그인하여 토큰과 회원 정보를 반환합니다.
+   *
+   * @param requestDto 로그인 요청 정보
+   * @return {@link LoginWithRefreshResponseDto} 토큰과 회원정보
+   */
   public LoginWithRefreshResponseDto login(LoginRequestDto requestDto) {
 
     Member member = memberQueryService.getMemberByEmail(requestDto.email());
@@ -40,7 +49,16 @@ public class AuthFacade {
     return authCommandService.login(member, requestDto.password());
   }
 
+  /**
+   * refreshToken을 검증하고 토큰을 재발급 합니다.
+   *
+   * @param request HTTP 요청(쿠키)
+   * @return {@link RefreshResponseDto} 새로 발급받은 토큰
+   */
   public RefreshResponseDto refresh(HttpServletRequest request) {
-    return authCommandService.refresh(request);
+
+    Member member = authQueryService.getMemberByRefreshToken(request);
+
+    return authCommandService.refresh(request, member);
   }
 }

--- a/src/main/java/com/example/demo/member/service/command/AuthCommandService.java
+++ b/src/main/java/com/example/demo/member/service/command/AuthCommandService.java
@@ -1,6 +1,9 @@
 package com.example.demo.member.service.command;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -15,11 +18,9 @@ import com.example.demo.member.dto.request.SignUpMemberRequestDto;
 import com.example.demo.member.dto.response.LoginResponseDto;
 import com.example.demo.member.dto.response.LoginWithRefreshResponseDto;
 import com.example.demo.member.dto.response.RefreshResponseDto;
-import com.example.demo.member.entity.Member;
-import com.example.demo.member.entity.MemberRole;
-import com.example.demo.member.entity.Password;
-import com.example.demo.member.entity.Tier;
+import com.example.demo.member.entity.*;
 import com.example.demo.member.entity.repository.MemberRepository;
+import com.example.demo.member.entity.repository.RefreshTokenBlackListRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthCommandService {
 
   private final MemberRepository memberRepository;
+  private final RefreshTokenBlackListRepository refreshTokenBlackListRepository;
   private final BCryptPasswordEncoder bCryptPasswordEncoder;
   private final JwtProvider jwtProvider;
 
@@ -114,11 +116,39 @@ public class AuthCommandService {
       throw new AuthException(GlobalErrorCode.REFRESH_TOKEN_MISMATCH);
     }
 
+    addToBlacklist(refreshToken);
+
     String newAccessToken = jwtProvider.generateAccessToken(member.getId());
     String newRefreshToken = jwtProvider.generateRefreshToken(member.getId());
 
     member.setRefreshToken(newRefreshToken);
 
     return new RefreshResponseDto(newAccessToken, newRefreshToken);
+  }
+
+  /**
+   * 재발급에 사용한 토큰을 BlackList에 저장합니다.
+   *
+   * @param refreshToken
+   * @return
+   * @throws AuthException {@code GlobalErrorCode.ALREADY_BLACKLIST_TOKEN} - 이미 BlackList에 등록되어있는 경우
+   * @throws AuthException {@code GlobalErrorCode.TOKEN_EXPIRED} - 토큰이 만료된 경우
+   */
+  private void addToBlacklist(String refreshToken) {
+    if (refreshTokenBlackListRepository.existsByRefreshToken(refreshToken)) {
+      throw new AuthException(GlobalErrorCode.ALREADY_BLACKLIST_TOKEN);
+    }
+
+    LocalDateTime expiredAt = jwtProvider.getExpiredAt(refreshToken);
+    long expirationMillis = Duration.between(LocalDateTime.now(), expiredAt).toMillis();
+
+    if (expirationMillis <= 0) {
+      throw new AuthException(GlobalErrorCode.TOKEN_EXPIRED);
+    }
+
+    refreshTokenBlackListRepository.save(
+        RefreshTokenBlackList.of(
+            refreshToken,
+            LocalDateTime.now().plusNanos(TimeUnit.MILLISECONDS.toNanos(expirationMillis))));
   }
 }

--- a/src/main/java/com/example/demo/member/service/query/AuthQueryService.java
+++ b/src/main/java/com/example/demo/member/service/query/AuthQueryService.java
@@ -1,9 +1,12 @@
 package com.example.demo.member.service.query;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.demo.global.exception.GlobalErrorCode;
+import com.example.demo.global.exception.custom.AuthException;
 import com.example.demo.global.exception.custom.MemberException;
 import com.example.demo.global.security.provider.JwtProvider;
 import com.example.demo.member.entity.Member;
@@ -14,33 +17,30 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class MemberQueryService {
+public class AuthQueryService {
 
   private final MemberRepository memberRepository;
   private final JwtProvider jwtProvider;
 
   /**
-   * 주어진 이메일이 중복되지 않는지 확인합니다.
+   * 주어진 refreshToken을 검증하고, 해당 회원을 조회합니다.
    *
-   * @param email 확인할 이메일 주소
-   * @throws MemberException {@code GlobalErrorCode.DUPLICATE_EMAIL} - 해당 이메일이 이미 존재하는 경우
-   */
-  public void isValidEmail(String email) {
-    if (memberRepository.existsByEmail(email)) {
-      throw new MemberException(GlobalErrorCode.DUPLICATE_EMAIL);
-    }
-  }
-
-  /**
-   * 주어진 이메일로 회원을 조회합니다.
-   *
-   * @param email 조회할 회원의 이메일
+   * @param request HTTP 요청(쿠키)
    * @return 조회된 {@link Member} 엔티티
-   * @throws MemberException {@code GlobalErrorCode.MEMBER_NOT_FOUND} - 해당 이메일로 회원을 찾을 수 없을 경우
+   * @throws AuthException {@code GlobalErrorCode.INVALID_TOKEN} - 해당 토큰이 유효하지 않은 경우
+   * @throws MemberException {@code GlobalErrorCode.MEMBER_NOT_FOUND} - 해당 회원이 존재하지 않은 경우
    */
-  public Member getMemberByEmail(String email) {
+  public Member getMemberByRefreshToken(HttpServletRequest request) {
+
+    String refreshToken =
+        jwtProvider
+            .extractRefreshToken(request)
+            .orElseThrow(() -> new AuthException(GlobalErrorCode.INVALID_TOKEN));
+
+    Long memberId = jwtProvider.getSubject(refreshToken);
+
     return memberRepository
-        .findByEmail(email)
+        .findById(memberId)
         .orElseThrow(() -> new MemberException(GlobalErrorCode.MEMBER_NOT_FOUND));
   }
 }

--- a/src/test/java/com/example/demo/Member/AuthQueryServiceTest.java
+++ b/src/test/java/com/example/demo/Member/AuthQueryServiceTest.java
@@ -1,0 +1,127 @@
+package com.example.demo.Member;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.demo.global.exception.GlobalErrorCode;
+import com.example.demo.global.exception.custom.AuthException;
+import com.example.demo.global.exception.custom.MemberException;
+import com.example.demo.global.security.provider.JwtProvider;
+import com.example.demo.member.entity.Member;
+import com.example.demo.member.entity.MemberRole;
+import com.example.demo.member.entity.Password;
+import com.example.demo.member.entity.Tier;
+import com.example.demo.member.entity.repository.MemberRepository;
+import com.example.demo.member.service.query.AuthQueryService;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthQueryServiceTest {
+
+  @Mock private MemberRepository memberRepository;
+  @Mock private JwtProvider jwtProvider;
+
+  @InjectMocks private AuthQueryService authQueryService;
+
+  private final Long testId = Long.parseLong(MemberTestConst.TEST_ID.getValue());
+  private final String testEmail = MemberTestConst.TEST_EMAIL.getValue();
+  private final String testPassword = MemberTestConst.TEST_PASSWORD.getValue();
+  private final String testNickname = MemberTestConst.TEST_NICKNAME.getValue();
+  private final String testProfileImage = MemberTestConst.TEST_PROFILE_IMAGE.getValue();
+  private final String testAccessToken = MemberTestConst.TEST_ACCESS_TOKEN.getValue();
+  private final String testRefreshToken = MemberTestConst.TEST_REFRESH_TOKEN.getValue();
+
+  @BeforeEach
+  void setUp() {}
+
+  @Nested
+  @DisplayName("토큰을 통해 유저를 조회 때")
+  class getMemberByRefreshToken {
+
+    Member testMember =
+        Member.builder()
+            .id(testId)
+            .email(testEmail)
+            .password(new Password(testPassword))
+            .nickname(testNickname)
+            .profileImage(testProfileImage)
+            .memberRole(MemberRole.USER)
+            .tier(Tier.UNRANK)
+            .build();
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    @Test
+    @DisplayName("사용자를 반환합니다.")
+    void getMemberByRefreshToken_Success() {
+      // give
+      when(jwtProvider.extractRefreshToken(request)).thenReturn(Optional.of(testRefreshToken));
+      when(jwtProvider.getSubject(testRefreshToken)).thenReturn(testId);
+      when(memberRepository.findById(testId)).thenReturn(Optional.of(testMember));
+
+      // when
+      Member member = authQueryService.getMemberByRefreshToken(request);
+
+      // then
+      assertNotNull(member, "반환된 사용자가 null이면 안됩니다.");
+      assertEquals(testMember, member, "반환된 값이 사용자와 일치해야 합니다.");
+      verify(jwtProvider, times(1)).extractRefreshToken(request);
+      verify(jwtProvider, times(1)).getSubject(testRefreshToken);
+      verify(memberRepository, times(1)).findById(testId);
+    }
+
+    @Test
+    @DisplayName("토큰이 유효하지 않으면 예외를 발생시킵니다.")
+    void getMemberByRefreshToken_Fail_Invalid_Token() {
+      // give
+      when(jwtProvider.extractRefreshToken(request)).thenReturn(Optional.empty());
+
+      // when
+      AuthException exception =
+          assertThrows(
+              AuthException.class, () -> authQueryService.getMemberByRefreshToken(request));
+
+      // then
+      assertEquals(
+          GlobalErrorCode.INVALID_TOKEN, exception.getErrorCode(), "에러 코드는 INVALID_TOKEN이어야 합니다.");
+      verify(jwtProvider, times(1)).extractRefreshToken(request);
+      verify(jwtProvider, never()).getSubject(anyString());
+      verify(memberRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않으면 예외를 발생시킵니다.")
+    void getMemberByRefreshToken_Fail_Member_Not_Found() {
+      // give
+      when(jwtProvider.extractRefreshToken(request)).thenReturn(Optional.of(testRefreshToken));
+      when(jwtProvider.getSubject(testRefreshToken)).thenReturn(testId);
+      when(memberRepository.findById(testId)).thenReturn(Optional.empty());
+
+      // when
+      MemberException exception =
+          assertThrows(
+              MemberException.class, () -> authQueryService.getMemberByRefreshToken(request));
+
+      // then
+      assertEquals(
+          GlobalErrorCode.MEMBER_NOT_FOUND,
+          exception.getErrorCode(),
+          "에러 코드는 MEMBER_NOT_FOUND이어야 합니다.");
+      verify(jwtProvider, times(1)).extractRefreshToken(request);
+      verify(jwtProvider, times(1)).getSubject(testRefreshToken);
+      verify(memberRepository, times(1)).findById(testId);
+    }
+  }
+}

--- a/src/test/java/com/example/demo/Member/MemberQueryServiceTest.java
+++ b/src/test/java/com/example/demo/Member/MemberQueryServiceTest.java
@@ -35,8 +35,6 @@ public class MemberQueryServiceTest {
   private final String testPassword = MemberTestConst.TEST_PASSWORD.getValue();
   private final String testNickname = MemberTestConst.TEST_NICKNAME.getValue();
   private final String testProfileImage = MemberTestConst.TEST_PROFILE_IMAGE.getValue();
-  private final String testAccessToken = MemberTestConst.TEST_ACCESS_TOKEN.getValue();
-  private final String testRefreshToken = MemberTestConst.TEST_REFRESH_TOKEN.getValue();
 
   @BeforeEach
   void setUp() {}


### PR DESCRIPTION
# 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# ❗️ 관련 이슈 링크
Close #15 

# 📌 개요
- refresh 토큰을 검증하고 새 토큰을 발급하며, 사용된 토큰을 블랙리스트에 추가하여 재사용을 방지합니다.
- 단일 서버기에 Redis같은 인메모리 DB를 사용하는 비용보다 DB에 저장하는 비용이 더 낮다는 결론을 내려 DB에 RefreshToken을 저장합니다.

# 🔁 변경 사항
1. **AuthCommandService**
   - `refresh` 메서드 개선: 요청 토큰과 DB 토큰 비교 후 새 토큰 발급 및 저장.
   - `addToBlacklist` 메서드 추가: 사용된 리프레시 토큰을 블랙리스트에 저장.
 
2. **AuthQueryService**
   - `getMemberByRefreshToken` 메서드: 리프레시 토큰으로 회원 조회.

# 👀 기타 더 이야기해볼 점

![2025-03-03 20;44;13](https://github.com/user-attachments/assets/a91af725-66d3-4e5d-b585-28474b398050)
![2025-03-03 19;47;36](https://github.com/user-attachments/assets/62049467-6412-4fc7-9b13-91e827159071)
![2025-03-03 20;43;40](https://github.com/user-attachments/assets/6f98d63b-85f5-4983-bf36-4487fa12bded)

# ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.