### PR TITLE
[Feat] : 내 게시판 조회 구현

### DIFF
--- a/src/main/java/com/example/demo/board/controller/BoardController.java
+++ b/src/main/java/com/example/demo/board/controller/BoardController.java
@@ -1,16 +1,17 @@
 package com.example.demo.board.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.example.demo.board.controller.swagger.api.CreateBoardApiDocs;
-import com.example.demo.board.dto.BoardCreateRequestDto;
-import com.example.demo.board.dto.BoardCreateResponseDto;
+import com.example.demo.board.controller.swagger.api.GetMyBoardListApiDocs;
+import com.example.demo.board.dto.request.BoardCreateRequestDto;
+import com.example.demo.board.dto.response.BoardCreateResponseDto;
+import com.example.demo.board.dto.response.GetMyBoardListResponseDto;
 import com.example.demo.board.facade.BoardFacade;
 import com.example.demo.global.annotation.SwaggerDocs;
 import com.example.demo.global.exception.GlobalErrorCode;
@@ -38,5 +39,16 @@ public class BoardController {
                 GlobalErrorCode.CREATED,
                 BoardCreateResponseDto.fromBoard(
                     boardFacade.createBoard(requestDto, memberDetails.getMember()))));
+  }
+
+  @GetMapping("/my-board")
+  @SwaggerDocs(GetMyBoardListApiDocs.class)
+  public ResponseEntity<BaseResponse<List<GetMyBoardListResponseDto>>> getMyBoardList(
+      @AuthenticationPrincipal MemberDetails memberDetails,
+      @RequestParam(required = false) Long lastBoardId) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(
+            BaseResponse.onSuccess(
+                boardFacade.getMyBoardList(memberDetails.getMember(), lastBoardId)));
   }
 }

--- a/src/main/java/com/example/demo/board/controller/swagger/BoardSwaggerConst.java
+++ b/src/main/java/com/example/demo/board/controller/swagger/BoardSwaggerConst.java
@@ -15,14 +15,20 @@ public class BoardSwaggerConst {
               }
               """;
 
-  public static final String MEMBER_NOT_FOUND =
+  public static final String GET_MY_BOARD_LIST_SUCCESS =
       """
+          {
+            "isSuccess": true,
+            "code": "200",
+            "message": "요청에 성공하였습니다.",
+            "divideCode": "success",
+            "data": [
               {
-                "isSuccess": false,
-                "code": "404",
-                "message": "등록된 사용자가 없습니다.",
-                "divideCode": "40401",
-                "data": null
+                "id": 1,
+                "name": "string1",
+                "thumbnailImage": "string"
               }
-            """;
+            ]
+          }
+          """;
 }

--- a/src/main/java/com/example/demo/board/controller/swagger/api/GetMyBoardListApiDocs.java
+++ b/src/main/java/com/example/demo/board/controller/swagger/api/GetMyBoardListApiDocs.java
@@ -1,0 +1,30 @@
+package com.example.demo.board.controller.swagger.api;
+
+import org.springframework.http.MediaType;
+
+import com.example.demo.board.controller.swagger.BoardSwaggerConst;
+import com.example.demo.global.response.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public class GetMyBoardListApiDocs {
+
+  @Operation(summary = "내 게시판 목록 조회", description = "자신이 속한 게시판 목록을 조회합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "게시판 목록 조회 성공",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BaseResponse.class),
+                    examples = @ExampleObject(value = BoardSwaggerConst.GET_MY_BOARD_LIST_SUCCESS)))
+      })
+  public void getMyBoardList() {}
+}

--- a/src/main/java/com/example/demo/board/dto/request/BoardCreateRequestDto.java
+++ b/src/main/java/com/example/demo/board/dto/request/BoardCreateRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.demo.board.dto;
+package com.example.demo.board.dto.request;
 
 import java.util.List;
 

--- a/src/main/java/com/example/demo/board/dto/response/BoardCreateResponseDto.java
+++ b/src/main/java/com/example/demo/board/dto/response/BoardCreateResponseDto.java
@@ -1,4 +1,4 @@
-package com.example.demo.board.dto;
+package com.example.demo.board.dto.response;
 
 import com.example.demo.board.entity.Board;
 

--- a/src/main/java/com/example/demo/board/dto/response/GetMyBoardListResponseDto.java
+++ b/src/main/java/com/example/demo/board/dto/response/GetMyBoardListResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.demo.board.dto.response;
+
+import com.example.demo.board.entity.Board;
+
+import lombok.Builder;
+
+@Builder
+public record GetMyBoardListResponseDto(Long id, String name, String thumbnailImage) {
+  public static GetMyBoardListResponseDto fromBoard(Board board) {
+    return GetMyBoardListResponseDto.builder()
+        .id(board.getId())
+        .name(board.getName())
+        .thumbnailImage(board.getThumbnailImage())
+        .build();
+  }
+}

--- a/src/main/java/com/example/demo/board/entity/repository/BoardQueryDslRepository.java
+++ b/src/main/java/com/example/demo/board/entity/repository/BoardQueryDslRepository.java
@@ -1,0 +1,39 @@
+package com.example.demo.board.entity.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.board.dto.response.GetMyBoardListResponseDto;
+import com.example.demo.board.entity.QBoard;
+import com.example.demo.board.entity.QBoardMember;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class BoardQueryDslRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  public List<GetMyBoardListResponseDto> findBoardListByMemberId(
+      Long memberId, Long lastBoardId, int pageSize) {
+    QBoard board = QBoard.board;
+    QBoardMember boardMember = QBoardMember.boardMember;
+
+    return queryFactory
+        .select(
+            Projections.constructor(
+                GetMyBoardListResponseDto.class, board.id, board.name, board.thumbnailImage))
+        .from(boardMember)
+        .join(boardMember.board, board)
+        .where(
+            boardMember.member.id.eq(memberId),
+            lastBoardId == null ? null : board.id.lt(lastBoardId))
+        .orderBy(board.id.desc())
+        .limit(pageSize)
+        .fetch();
+  }
+}

--- a/src/main/java/com/example/demo/board/facade/BoardFacade.java
+++ b/src/main/java/com/example/demo/board/facade/BoardFacade.java
@@ -5,10 +5,12 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.demo.board.dto.BoardCreateRequestDto;
+import com.example.demo.board.dto.request.BoardCreateRequestDto;
+import com.example.demo.board.dto.response.GetMyBoardListResponseDto;
 import com.example.demo.board.entity.Board;
-import com.example.demo.board.service.BoardCommandService;
-import com.example.demo.board.service.BoardMemberCommandService;
+import com.example.demo.board.service.command.BoardCommandService;
+import com.example.demo.board.service.command.BoardMemberCommandService;
+import com.example.demo.board.service.query.BoardQueryService;
 import com.example.demo.member.entity.Member;
 import com.example.demo.member.service.query.MemberQueryService;
 
@@ -20,7 +22,11 @@ public class BoardFacade {
 
   private final BoardCommandService boardCommandService;
   private final BoardMemberCommandService boardMemberCommandService;
+  private final BoardQueryService boardQueryService;
+
   private final MemberQueryService memberQueryService;
+
+  private static final int DEFAULT_PAGE_SIZE = 10;
 
   /**
    * 주어진 요청 데이터를 기반으로 새로운 게시판을 생성하고, 게시판 방장 및 회원을 등록합니다.
@@ -42,5 +48,16 @@ public class BoardFacade {
     boardMemberCommandService.joinBoardMember(board, memberList);
 
     return board;
+  }
+
+  /**
+   * 주어진 회원이 참여한 게시판 목록을 조회합니다.
+   *
+   * @param member 조회할 {@link Member} 회원
+   * @param lastBoardId 마지막 조회된 게시판 ID (페이징 용, null 가능)
+   * @return 조회한 {@link GetMyBoardListResponseDto} 게시판 정보 목록
+   */
+  public List<GetMyBoardListResponseDto> getMyBoardList(Member member, Long lastBoardId) {
+    return boardQueryService.getMyBoardList(member.getId(), lastBoardId, DEFAULT_PAGE_SIZE);
   }
 }

--- a/src/main/java/com/example/demo/board/service/command/BoardCommandService.java
+++ b/src/main/java/com/example/demo/board/service/command/BoardCommandService.java
@@ -1,9 +1,9 @@
-package com.example.demo.board.service;
+package com.example.demo.board.service.command;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.demo.board.dto.BoardCreateRequestDto;
+import com.example.demo.board.dto.request.BoardCreateRequestDto;
 import com.example.demo.board.entity.Board;
 import com.example.demo.board.entity.repository.BoardRepository;
 

--- a/src/main/java/com/example/demo/board/service/command/BoardMemberCommandService.java
+++ b/src/main/java/com/example/demo/board/service/command/BoardMemberCommandService.java
@@ -1,4 +1,4 @@
-package com.example.demo.board.service;
+package com.example.demo.board.service.command;
 
 import java.util.List;
 

--- a/src/main/java/com/example/demo/board/service/query/BoardQueryService.java
+++ b/src/main/java/com/example/demo/board/service/query/BoardQueryService.java
@@ -1,0 +1,32 @@
+package com.example.demo.board.service.query;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.board.dto.response.GetMyBoardListResponseDto;
+import com.example.demo.board.entity.repository.BoardQueryDslRepository;
+import com.example.demo.global.annotation.ReadOnlyTransactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@ReadOnlyTransactional
+public class BoardQueryService {
+
+  private final BoardQueryDslRepository boardQueryDslRepository;
+
+  /**
+   * 회원이 참여한 게시판 목록을 조회합니다.
+   *
+   * @param memberId 조회할 회원 ID
+   * @param lastBoardId 마지막 조회된 게시판 ID (페이징 용)
+   * @param pageSize 페이지 크기
+   * @return 조회한 {@link GetMyBoardListResponseDto} 게시판 정보 목록
+   */
+  public List<GetMyBoardListResponseDto> getMyBoardList(
+      Long memberId, Long lastBoardId, int pageSize) {
+    return boardQueryDslRepository.findBoardListByMemberId(memberId, lastBoardId, pageSize);
+  }
+}

--- a/src/main/java/com/example/demo/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/demo/global/config/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package com.example.demo.global.config;
+
+import jakarta.persistence.EntityManager;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Configuration
+public class QueryDslConfig {
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/example/demo/member/controller/swagger/api/GetMemberByIdentifiedCodeApiDocs.java
+++ b/src/main/java/com/example/demo/member/controller/swagger/api/GetMemberByIdentifiedCodeApiDocs.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 public class GetMemberByIdentifiedCodeApiDocs {
 
-  @Operation(summary = "게시판 생성", description = "게시판을 생성하고 회원을 초대합니다.")
+  @Operation(summary = "식별코드로 회원 조회", description = "식별코드를 통해 회원을 조회합니다.")
   @ApiResponses(
       value = {
         @ApiResponse(

--- a/src/test/java/com/example/demo/board/BoardCommandServiceTest.java
+++ b/src/test/java/com/example/demo/board/BoardCommandServiceTest.java
@@ -13,10 +13,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.example.demo.board.dto.BoardCreateRequestDto;
+import com.example.demo.board.dto.request.BoardCreateRequestDto;
 import com.example.demo.board.entity.Board;
 import com.example.demo.board.entity.repository.BoardRepository;
-import com.example.demo.board.service.BoardCommandService;
+import com.example.demo.board.service.command.BoardCommandService;
 
 @ExtendWith(MockitoExtension.class)
 public class BoardCommandServiceTest {

--- a/src/test/java/com/example/demo/board/BoardMemberCommandServiceTest.java
+++ b/src/test/java/com/example/demo/board/BoardMemberCommandServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.example.demo.board.entity.Board;
 import com.example.demo.board.entity.BoardMember;
 import com.example.demo.board.entity.repository.BoardMemberRepository;
-import com.example.demo.board.service.BoardMemberCommandService;
+import com.example.demo.board.service.command.BoardMemberCommandService;
 import com.example.demo.member.entity.Member;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/example/demo/board/BoardQueryServiceTest.java
+++ b/src/test/java/com/example/demo/board/BoardQueryServiceTest.java
@@ -1,0 +1,82 @@
+package com.example.demo.board;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.demo.board.dto.response.GetMyBoardListResponseDto;
+import com.example.demo.board.entity.repository.BoardQueryDslRepository;
+import com.example.demo.board.service.query.BoardQueryService;
+
+@ExtendWith(MockitoExtension.class)
+public class BoardQueryServiceTest {
+
+  @Mock private BoardQueryDslRepository boardQueryDslRepository;
+
+  @InjectMocks private BoardQueryService boardQueryService;
+
+  private final Long testMemberId = Long.parseLong(BoardTestConst.TEST_MEMBER_ID.getValue());
+  private final Long testLastBoardId = Long.parseLong(BoardTestConst.TEST_LAST_BOARD_ID.getValue());
+  private final int testPageSize = Integer.parseInt(BoardTestConst.TEST_PAGE_SIZE.getValue());
+
+  @BeforeEach
+  void setUp() {}
+
+  @Nested
+  @DisplayName("내가 속한 게시판을 조회 할 때")
+  class GetMyBoardList {
+    @Test
+    @DisplayName("정상적으로 게시판 목록을 조회합니다.")
+    void getMyBoardList_Success() {
+      // give
+      List<GetMyBoardListResponseDto> getMyBoardListResponseDtoList =
+          List.of(
+              new GetMyBoardListResponseDto(1L, "Board1", "thumbnail1.png"),
+              new GetMyBoardListResponseDto(2L, "Board2", "thumbnail2.png"));
+      when(boardQueryDslRepository.findBoardListByMemberId(
+              testMemberId, testLastBoardId, testPageSize))
+          .thenReturn(getMyBoardListResponseDtoList);
+
+      // when
+      List<GetMyBoardListResponseDto> testList =
+          boardQueryService.getMyBoardList(testMemberId, testLastBoardId, testPageSize);
+
+      // then
+      assertNotNull(testList, "반환된 리스트는 null이면 안됩니다");
+      assertEquals(2, testList.size(), "리스트 크기가 일치해야 합니다");
+      assertEquals(getMyBoardListResponseDtoList, testList, "반환된 리스트가 예상과 일치해야 합니다");
+      verify(boardQueryDslRepository, times(1))
+          .findBoardListByMemberId(testMemberId, testLastBoardId, testPageSize);
+    }
+
+    @Test
+    @DisplayName("게시판이 없으면 빈 리스트를 반환합니다")
+    void getMyBoardList_Success_EmptyList() {
+      // give
+      when(boardQueryDslRepository.findBoardListByMemberId(
+              testMemberId, testLastBoardId, testPageSize))
+          .thenReturn(Collections.emptyList());
+
+      // when
+      List<GetMyBoardListResponseDto> result =
+          boardQueryService.getMyBoardList(testMemberId, testLastBoardId, testPageSize);
+
+      // then
+      assertNotNull(result, "반환된 리스트는 null이면 안됩니다");
+      assertTrue(result.isEmpty(), "빈 리스트가 반환되어야 합니다");
+      verify(boardQueryDslRepository, times(1))
+          .findBoardListByMemberId(testMemberId, testLastBoardId, testPageSize);
+    }
+  }
+}

--- a/src/test/java/com/example/demo/board/BoardTestConst.java
+++ b/src/test/java/com/example/demo/board/BoardTestConst.java
@@ -5,7 +5,9 @@ public enum BoardTestConst {
   TEST_NAME("testBoard"),
   TEST_THUMBNAIL("testThumbnail"),
   DEFAULT_THUMBNAIL("default-thumbnail.png"),
-  ;
+  TEST_MEMBER_ID("1"),
+  TEST_LAST_BOARD_ID("10"),
+  TEST_PAGE_SIZE("5");
 
   private final String value;
 


### PR DESCRIPTION
# 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# ❗️ 관련 이슈 링크
Close #27 

# 📌 개요
- 내가 속한 게시판을 조회합니다.
- RESTful API로 '/api/board/my-board'를 추가하였습니다.


# 🔁 변경 사항
1. **BoardController**
   - `GET /api/board/my-board` 엔드 포인트 추가
   - SwaggerApiDocs 작성

2. **BoardQueryService**
   - `getMyBoardList(Long, Long, int)` 메서드 구현 : 내가 속한 게시판 조회

# 👀 기타 더 이야기해볼 점

![get](https://github.com/user-attachments/assets/42c855b0-4219-4116-9640-481ed982829d)
![BoardQueryServiceTest](https://github.com/user-attachments/assets/eede7a79-5d33-4d2c-a881-839d3eba2e1e)

# ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.