### PR TITLE
[Feat] : 게시글 조회 구현

### DIFF
--- a/src/main/java/com/example/demo/CoboardApplication.java
+++ b/src/main/java/com/example/demo/CoboardApplication.java
@@ -2,8 +2,11 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 public class CoboardApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/example/demo/post/controller/PostController.java
+++ b/src/main/java/com/example/demo/post/controller/PostController.java
@@ -1,5 +1,9 @@
 package com.example.demo.post.controller;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -10,7 +14,9 @@ import com.example.demo.global.exception.GlobalErrorCode;
 import com.example.demo.global.response.BaseResponse;
 import com.example.demo.global.security.domain.MemberDetails;
 import com.example.demo.post.controller.swagger.api.CreatePostApiDocs;
+import com.example.demo.post.controller.swagger.api.GetPostListInBoardApiDocs;
 import com.example.demo.post.dto.CreatePostRequestDto;
+import com.example.demo.post.dto.GetPostListInBoardResponseDto;
 import com.example.demo.post.facade.PostFacade;
 
 import lombok.RequiredArgsConstructor;
@@ -31,5 +37,17 @@ public class PostController {
     postFacade.createPost(requestDto, boardId, memberDetails.getMember());
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(BaseResponse.onSuccess(GlobalErrorCode.CREATED, null));
+  }
+
+  @GetMapping("/{boardId}")
+  @SwaggerDocs(GetPostListInBoardApiDocs.class)
+  public ResponseEntity<BaseResponse<Page<GetPostListInBoardResponseDto>>> getPostListInBoard(
+      @PathVariable(name = "boardId") Long boardId,
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+          Pageable pageable) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(
+            BaseResponse.onSuccess(
+                GlobalErrorCode.OK, postFacade.getPostListInBoard(boardId, pageable)));
   }
 }

--- a/src/main/java/com/example/demo/post/controller/swagger/PostSwaggerConst.java
+++ b/src/main/java/com/example/demo/post/controller/swagger/PostSwaggerConst.java
@@ -9,7 +9,6 @@ public class PostSwaggerConst {
               "code": "201",
               "message": "요청 성공 및 리소스 생성됨",
               "divideCode": "20101",
-              "timestamp": "2025-03-10 14:48:53"
             }
             """;
 
@@ -34,4 +33,31 @@ public class PostSwaggerConst {
                 "data": null
               }
             """;
+
+  public static final String GET_POST_IN_BOARD_SUCCESS =
+      """
+                {
+                  "isSuccess": true,
+                  "code": "200",
+                  "message": "요청 성공",
+                  "divideCode": "20001",
+                  "data": {
+                    "content": [
+                      {
+                        "title": "string",
+                        "likeCount": 0,
+                        "averageRating": 0,
+                        "createdAt": "",
+                        "nickname": "string"
+                      }
+                    ],
+                    "page": {
+                      "size": 10,
+                      "number": 0,
+                      "totalElements": 0,
+                      "totalPages": 0
+                    }
+                  }
+                }
+                """;
 }

--- a/src/main/java/com/example/demo/post/controller/swagger/api/GetPostListInBoardApiDocs.java
+++ b/src/main/java/com/example/demo/post/controller/swagger/api/GetPostListInBoardApiDocs.java
@@ -1,0 +1,29 @@
+package com.example.demo.post.controller.swagger.api;
+
+import org.springframework.http.MediaType;
+
+import com.example.demo.global.response.BaseResponse;
+import com.example.demo.post.controller.swagger.PostSwaggerConst;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public class GetPostListInBoardApiDocs {
+  @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "20001",
+            description = "게시글 조회 성공",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BaseResponse.class),
+                    examples = @ExampleObject(value = PostSwaggerConst.GET_POST_IN_BOARD_SUCCESS)))
+      })
+  public void getPostListInBoard() {}
+}

--- a/src/main/java/com/example/demo/post/dto/GetPostListInBoardResponseDto.java
+++ b/src/main/java/com/example/demo/post/dto/GetPostListInBoardResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.demo.post.dto;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record GetPostListInBoardResponseDto(
+    String title,
+    Integer likeCount,
+    Float averageRating,
+    LocalDateTime createdAt,
+    String nickname) {
+
+  @QueryProjection
+  public GetPostListInBoardResponseDto(
+      String title,
+      Integer likeCount,
+      Float averageRating,
+      LocalDateTime createdAt,
+      String nickname) {
+    this.title = title;
+    this.likeCount = likeCount;
+    this.averageRating = averageRating;
+    this.createdAt = createdAt;
+    this.nickname = nickname;
+  }
+}

--- a/src/main/java/com/example/demo/post/entity/Post.java
+++ b/src/main/java/com/example/demo/post/entity/Post.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.*;
 
+import com.example.demo.board.entity.Board;
 import com.example.demo.board.entity.BoardMember;
 
 import lombok.*;
@@ -37,6 +38,10 @@ public class Post {
 
   @Column(name = "created_at")
   private LocalDateTime createdAt;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "board_id")
+  private Board board;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "board_member_id")

--- a/src/main/java/com/example/demo/post/entity/Post.java
+++ b/src/main/java/com/example/demo/post/entity/Post.java
@@ -10,7 +10,15 @@ import com.example.demo.board.entity.BoardMember;
 import lombok.*;
 
 @Entity
-@Table(name = "post")
+@Table(
+    name = "post",
+    indexes = {
+      @Index(name = "idx_post_board_id", columnList = "board_id"),
+      @Index(name = "idx_post_created_at_post_id", columnList = "board_id, post_id, created_at"),
+      @Index(name = "idx_post_like_count", columnList = "board_id, like_count"),
+      @Index(name = "idx_post_average_rating", columnList = "board_id, average_rating"),
+      @Index(name = "idx_post_board_member_id", columnList = "board_member_id")
+    })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/demo/post/entity/repository/PostQueryDslRepository.java
+++ b/src/main/java/com/example/demo/post/entity/repository/PostQueryDslRepository.java
@@ -59,7 +59,7 @@ public class PostQueryDslRepository {
                 switch (order.getProperty()) {
                   case "likeCount" -> post.likeCount.desc();
                   case "averageRating" -> post.averageRating.desc();
-                  default -> new OrderSpecifier[] {post.createdAt.desc(), post.id.desc()};
+                  default -> new OrderSpecifier[] {post.id.desc(), post.createdAt.desc()};
                 })
         .flatMap(
             spec ->

--- a/src/main/java/com/example/demo/post/entity/repository/PostQueryDslRepository.java
+++ b/src/main/java/com/example/demo/post/entity/repository/PostQueryDslRepository.java
@@ -1,0 +1,71 @@
+package com.example.demo.post.entity.repository;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.board.entity.QBoardMember;
+import com.example.demo.member.entity.QMember;
+import com.example.demo.post.dto.GetPostListInBoardResponseDto;
+import com.example.demo.post.dto.QGetPostListInBoardResponseDto;
+import com.example.demo.post.entity.QPost;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class PostQueryDslRepository {
+
+  private final JPAQueryFactory queryFactory;
+  private static final QPost post = QPost.post;
+  private static final QBoardMember boardMember = QBoardMember.boardMember;
+  private static final QMember member = QMember.member;
+
+  public Page<GetPostListInBoardResponseDto> findPostListByBoard(Long boardId, Pageable pageable) {
+    List<GetPostListInBoardResponseDto> content =
+        queryFactory
+            .select(
+                new QGetPostListInBoardResponseDto(
+                    post.title,
+                    post.likeCount,
+                    post.averageRating,
+                    post.createdAt,
+                    member.nickname))
+            .from(post)
+            .leftJoin(post.boardMember, boardMember)
+            .leftJoin(boardMember.member, member)
+            .where(post.board.id.eq(boardId))
+            .orderBy(getOrderSpecifiers(pageable))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+    Long total =
+        queryFactory.select(post.count()).from(post).where(post.board.id.eq(boardId)).fetchOne();
+
+    return new PageImpl<>(content, pageable, total != null ? total : 0L);
+  }
+
+  private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+    return pageable.getSort().stream()
+        .map(
+            order ->
+                switch (order.getProperty()) {
+                  case "likeCount" -> post.likeCount.desc();
+                  case "averageRating" -> post.averageRating.desc();
+                  default -> new OrderSpecifier[] {post.createdAt.desc(), post.id.desc()};
+                })
+        .flatMap(
+            spec ->
+                spec instanceof OrderSpecifier<?>[]
+                    ? Stream.of((OrderSpecifier<?>[]) spec)
+                    : Stream.of((OrderSpecifier<?>) spec))
+        .toArray(OrderSpecifier[]::new);
+  }
+}

--- a/src/main/java/com/example/demo/post/facade/PostFacade.java
+++ b/src/main/java/com/example/demo/post/facade/PostFacade.java
@@ -1,5 +1,7 @@
 package com.example.demo.post.facade;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import com.example.demo.board.entity.Board;
@@ -8,7 +10,9 @@ import com.example.demo.board.service.query.BoardMemberQueryService;
 import com.example.demo.board.service.query.BoardQueryService;
 import com.example.demo.member.entity.Member;
 import com.example.demo.post.dto.CreatePostRequestDto;
+import com.example.demo.post.dto.GetPostListInBoardResponseDto;
 import com.example.demo.post.service.PostCommandService;
+import com.example.demo.post.service.PostQueryService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class PostFacade {
 
   private final PostCommandService postCommandService;
+  private final PostQueryService postQueryService;
 
   private final BoardQueryService boardQueryService;
   private final BoardMemberQueryService boardMemberQueryService;
@@ -34,6 +39,17 @@ public class PostFacade {
 
     BoardMember boardMember = boardMemberQueryService.getBoardMemberByBoardAndMember(board, member);
 
-    postCommandService.createPost(requestDto, boardMember);
+    postCommandService.createPost(requestDto, boardMember, board);
+  }
+
+  /**
+   * 주어진 게시판 ID와 페이지 요청 정보를 기반으로 해당 게시판 내의 게시글 목록을 조회합니다.
+   *
+   * @param boardId 게시글을 찾을 게시판 ID
+   * @param pageable 페이지네이션 및 정렬 정보를 포함하는 객체
+   * @return 해당 게시판의 게시글 목록을 포함하는 {@link Page} 객체
+   */
+  public Page<GetPostListInBoardResponseDto> getPostListInBoard(Long boardId, Pageable pageable) {
+    return postQueryService.getPostListInBoard(boardId, pageable);
   }
 }

--- a/src/main/java/com/example/demo/post/service/PostCommandService.java
+++ b/src/main/java/com/example/demo/post/service/PostCommandService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.demo.board.entity.Board;
 import com.example.demo.board.entity.BoardMember;
 import com.example.demo.post.dto.CreatePostRequestDto;
 import com.example.demo.post.entity.Post;
@@ -26,12 +27,13 @@ public class PostCommandService {
    * @param requestDto 게시글 생성 요청 데이터 {@link CreatePostRequestDto} (게시글 제목, 코드 언어, 코드 내용)
    * @param boardMember 주어진 {@link BoardMember} 게시판 회원
    */
-  public void createPost(CreatePostRequestDto requestDto, BoardMember boardMember) {
+  public void createPost(CreatePostRequestDto requestDto, BoardMember boardMember, Board board) {
     Post post =
         Post.builder()
             .title(requestDto.title())
             .postCode(createPostCode(requestDto))
             .createdAt(LocalDateTime.now())
+            .board(board)
             .boardMember(boardMember)
             .build();
 

--- a/src/main/java/com/example/demo/post/service/PostQueryService.java
+++ b/src/main/java/com/example/demo/post/service/PostQueryService.java
@@ -1,0 +1,30 @@
+package com.example.demo.post.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.example.demo.global.annotation.ReadOnlyTransactional;
+import com.example.demo.post.dto.GetPostListInBoardResponseDto;
+import com.example.demo.post.entity.repository.PostQueryDslRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@ReadOnlyTransactional
+public class PostQueryService {
+
+  private final PostQueryDslRepository postQueryDslRepository;
+
+  /**
+   * 주어진 게시판 ID와 페이지 요청 정보를 기반으로 해당 게시판 내의 게시글 목록을 조회합니다.
+   *
+   * @param boardId 게시글을 찾을 게시판 ID
+   * @param pageable 페이지네이션 및 정렬 정보를 포함하는 객체
+   * @return 해당 게시판의 게시글 목록을 포함하는 {@link Page} 객체
+   */
+  public Page<GetPostListInBoardResponseDto> getPostListInBoard(Long boardId, Pageable pageable) {
+    return postQueryDslRepository.findPostListByBoard(boardId, pageable);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        show_sql: true
   sql:
     init:
       mode: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
       settings:
         web-allow-others: true
   datasource:
-    url: jdbc:h2:mem:test
+    url: jdbc:h2:mem:test;CACHE_SIZE=131072
     driver-class-name: org.h2.Driver
     username: test
     password: test
@@ -29,7 +29,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        show_sql: true
   sql:
     init:
       mode: always

--- a/src/test/java/com/example/demo/post/PostCommandServiceTest.java
+++ b/src/test/java/com/example/demo/post/PostCommandServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.example.demo.board.entity.Board;
 import com.example.demo.board.entity.BoardMember;
 import com.example.demo.post.dto.CreatePostRequestDto;
 import com.example.demo.post.entity.CodeLanguage;
@@ -52,19 +53,22 @@ public class PostCommandServiceTest {
       PostCode testPostCode =
           PostCode.builder().language(CodeLanguage.C).content(requestDto.content()).build();
 
+      Board mockBoard = mock(Board.class);
+
       BoardMember mockBoardMember = mock(BoardMember.class);
 
       Post testPost =
           Post.builder()
               .title(requestDto.title())
               .postCode(testPostCode)
+              .board(mockBoard)
               .boardMember(mockBoardMember)
               .build();
 
       when(postJpaRepository.save(any(Post.class))).thenReturn(testPost);
 
       // when
-      postCommandService.createPost(requestDto, mockBoardMember);
+      postCommandService.createPost(requestDto, mockBoardMember, mockBoard);
 
       // then
       ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
@@ -76,6 +80,7 @@ public class PostCommandServiceTest {
           requestDto.language(), capturedPost.getPostCode().getLanguage(), "게시글 코드 언어가 일치해야합니다.");
       assertEquals(
           requestDto.content(), capturedPost.getPostCode().getContent(), "게시글의 코드가 일치해야합니다.");
+      assertEquals(mockBoard, capturedPost.getBoard(), "게시판과 게시된 게시판이 일치해야합니다.");
       assertEquals(mockBoardMember, capturedPost.getBoardMember(), "작성자와 게시글 회원이 일치해야합니다.");
     }
   }

--- a/src/test/java/com/example/demo/post/PostQueryServiceTest.java
+++ b/src/test/java/com/example/demo/post/PostQueryServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.demo.post;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.example.demo.post.dto.GetPostListInBoardResponseDto;
+import com.example.demo.post.entity.repository.PostQueryDslRepository;
+import com.example.demo.post.service.PostQueryService;
+
+@ExtendWith(MockitoExtension.class)
+public class PostQueryServiceTest {
+
+  @Mock private PostQueryDslRepository postQueryDslRepository;
+
+  @InjectMocks private PostQueryService postQueryService;
+
+  private final Long testId = Long.parseLong(PostTestConst.TEST_ID.getValue());
+  private final String testTitle = PostTestConst.TEST_TITLE.getValue();
+  private final Integer testLikeCount = Integer.parseInt(PostTestConst.TEST_COUNT.getValue());
+  private final Float testAverageRating = Float.parseFloat(PostTestConst.TEST_COUNT.getValue());
+  private final String testNickname = PostTestConst.TEST_TITLE.getValue();
+
+  @Nested
+  @DisplayName("게시판의 게시글을 조회할 때")
+  class getPostListInBoard {
+    @Test
+    @DisplayName("게시판의 글을 조회합니다.")
+    void getPostListInBoard_Success() {
+      // give
+      GetPostListInBoardResponseDto responseDto =
+          new GetPostListInBoardResponseDto(
+              testTitle, testLikeCount, testAverageRating, LocalDateTime.now(), testNickname);
+
+      Pageable testPageable = PageRequest.of(0, 10);
+
+      List<GetPostListInBoardResponseDto> content = Collections.singletonList(responseDto);
+      Page<GetPostListInBoardResponseDto> mockPage = new PageImpl<>(content, testPageable, 1);
+
+      when(postQueryDslRepository.findPostListByBoard(testId, testPageable)).thenReturn(mockPage);
+
+      // when
+      Page<GetPostListInBoardResponseDto> result =
+          postQueryService.getPostListInBoard(testId, testPageable);
+
+      // then
+      assertNotNull(result, "조회 결과가 null이면 안됩니다.");
+      assertEquals(1, result.getTotalElements(), "총 개수는 1입니다.");
+      assertEquals(1, result.getContent().size(), "content 크기는 1입니다.");
+      assertEquals(testTitle, result.getContent().getFirst().title(), "제목이 일치해야합니다.");
+      assertEquals(testNickname, result.getContent().getFirst().nickname(), "닉네임이 일치해야합니다.");
+
+      verify(postQueryDslRepository, times(1)).findPostListByBoard(testId, testPageable);
+    }
+  }
+}

--- a/src/test/java/com/example/demo/post/PostTestConst.java
+++ b/src/test/java/com/example/demo/post/PostTestConst.java
@@ -3,7 +3,8 @@ package com.example.demo.post;
 public enum PostTestConst {
   TEST_ID("1"),
   TEST_TITLE("testPost"),
-  TEST_CONTENT("testContent");
+  TEST_CONTENT("testContent"),
+  TEST_COUNT("0");
 
   private final String value;
 

--- a/src/test/java/com/example/demo/post/performance/IndexTest.java
+++ b/src/test/java/com/example/demo/post/performance/IndexTest.java
@@ -1,0 +1,353 @@
+package com.example.demo.post.performance;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.example.demo.board.entity.Board;
+import com.example.demo.board.entity.BoardMember;
+import com.example.demo.member.entity.Member;
+import com.example.demo.member.entity.MemberRole;
+import com.example.demo.member.entity.Password;
+import com.example.demo.member.entity.Tier;
+import com.example.demo.post.dto.GetPostListInBoardResponseDto;
+import com.example.demo.post.entity.CodeLanguage;
+import com.example.demo.post.entity.PostCode;
+import com.example.demo.post.service.PostQueryService;
+
+@SpringBootTest
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class IndexTest {
+
+  @Autowired private PostQueryService postQueryService;
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @PersistenceContext EntityManager entityManager;
+
+  @Autowired TransactionTemplate transactionTemplate;
+
+  private static final int BULK_INSERT_SIZE = 1000;
+  private static final int EXECUTE_COUNT = 2000;
+  private static final int TOTAL_POSTS = BULK_INSERT_SIZE * EXECUTE_COUNT;
+  private static final int REPEAT_COUNT = 10;
+
+  private Member testMember;
+  private Board testBoard;
+  private BoardMember testBoardMember;
+  private PostCode testPostCode;
+
+  @BeforeEach
+  void setupTestData() throws InterruptedException {
+    setupInitialData();
+
+    insertData();
+  }
+
+  private void setupInitialData() {
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          testMember =
+              Member.builder()
+                  .email("testEmail")
+                  .password(new Password("testPassword"))
+                  .nickname("testNickname")
+                  .profileImage("testProfileImage")
+                  .identifiedCode("test")
+                  .memberRole(MemberRole.USER)
+                  .tier(Tier.UNRANK)
+                  .build();
+          entityManager.persist(testMember);
+
+          testBoard = Board.builder().name("testName").thumbnailImage("testThumbnailImage").build();
+          entityManager.persist(testBoard);
+
+          testBoardMember =
+              BoardMember.builder().board(testBoard).member(testMember).isLeader(true).build();
+          entityManager.persist(testBoardMember);
+
+          testPostCode =
+              PostCode.builder().language(CodeLanguage.JAVA).content("testContent").build();
+          entityManager.flush();
+        });
+  }
+
+  @AfterEach
+  void clearDatabase() {
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          entityManager.createNativeQuery("DELETE FROM post").executeUpdate();
+          entityManager.createNativeQuery("DELETE FROM board_member").executeUpdate();
+          entityManager.createNativeQuery("DELETE FROM board").executeUpdate();
+          entityManager.createNativeQuery("DELETE FROM member").executeUpdate();
+          entityManager.clear();
+          entityManager.getEntityManagerFactory().getCache().evictAll();
+        });
+
+    System.out.println("DB 초기화 완료");
+  }
+
+  private void insertData() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(EXECUTE_COUNT);
+    ExecutorService executorService = Executors.newFixedThreadPool(4);
+
+    // 인덱스 일시 삭제
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          try {
+            entityManager
+                .createNativeQuery("DROP INDEX idx_post_created_at_post_id ON POST")
+                .executeUpdate();
+          } catch (Exception e) {
+            System.out.println("Index drop failed: " + e.getMessage());
+          }
+        });
+
+    long startTime = System.nanoTime();
+    for (int i = 0; i < EXECUTE_COUNT; i++) {
+      final int batchNumber = i;
+      executorService.submit(
+          () -> {
+            try {
+              transactionTemplate.executeWithoutResult(status -> insert(batchNumber));
+            } catch (Exception e) {
+              System.err.println("Insert failed for batch " + batchNumber + ": " + e.getMessage());
+            } finally {
+              latch.countDown();
+              System.out.println("latch.getCount() = " + latch.getCount());
+              if (batchNumber % 500 == 0) { // 500번째 배치마다 출력
+                long elapsed = (System.nanoTime() - startTime) / 1_000_000;
+                System.out.println(
+                    "Batch "
+                        + batchNumber
+                        + ", latch.getCount() = "
+                        + latch.getCount()
+                        + ", Time elapsed: "
+                        + elapsed
+                        + "ms");
+              }
+            }
+          });
+    }
+
+    latch.await();
+    executorService.shutdown();
+    executorService.awaitTermination(10, TimeUnit.MINUTES);
+
+    Long count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM POST", Long.class);
+    System.out.println(
+        "Total inserted posts: "
+            + count
+            + ", Total time: "
+            + (System.nanoTime() - startTime) / 1_000_000
+            + "ms");
+
+    // 인덱스 복구
+    transactionTemplate.executeWithoutResult(
+        status ->
+            entityManager
+                .createNativeQuery(
+                    "CREATE INDEX idx_post_created_at_post_id ON POST (board_id, post_id DESC, created_at DESC)")
+                .executeUpdate());
+  }
+
+  private void insert(int batchNumber) {
+    jdbcTemplate.batchUpdate(
+        "INSERT INTO POST (title, created_at, board_id, board_member_id, language, content, like_count, average_rating) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        new BatchPreparedStatementSetter() {
+          @Override
+          public void setValues(PreparedStatement ps, int i) throws SQLException {
+            ps.setString(1, "title_" + batchNumber + "_" + i);
+            ps.setTimestamp(2, Timestamp.valueOf(LocalDateTime.now()));
+            ps.setLong(3, testBoard.getId());
+            ps.setLong(4, testBoardMember.getId());
+            ps.setString(5, testPostCode.getLanguage().name());
+            ps.setString(6, testPostCode.getContent());
+            ps.setInt(7, 0);
+            ps.setFloat(8, 0.0f);
+          }
+
+          @Override
+          public int getBatchSize() {
+            return BULK_INSERT_SIZE;
+          }
+        });
+  }
+
+  @Nested
+  @DisplayName("인덱스 성능 테스트")
+  class GetPostInBoard {
+
+    int pageSize = 20;
+    int totalPosts = TOTAL_POSTS;
+    int middlePage = totalPosts / (2 * pageSize);
+    int lastPage = (totalPosts / pageSize) - 1;
+
+    private List<Long> withIndexTimesStart = new ArrayList<>();
+    private List<Long> withIndexTimesMiddle = new ArrayList<>();
+    private List<Long> withIndexTimesEnd = new ArrayList<>();
+    private List<Long> withoutIndexTimesStart = new ArrayList<>();
+    private List<Long> withoutIndexTimesMiddle = new ArrayList<>();
+    private List<Long> withoutIndexTimesEnd = new ArrayList<>();
+
+    @RepeatedTest(
+        value = REPEAT_COUNT,
+        name = "{displayName} - 반복 {currentRepetition}/{totalRepetitions}")
+    @DisplayName("인덱스가 있는 경우")
+    void getPostInBoard_With_Index() {
+
+      long startResultStartTime = System.nanoTime();
+
+      Page<GetPostListInBoardResponseDto> startResult =
+          postQueryService.getPostListInBoard(testBoard.getId(), PageRequest.of(0, pageSize));
+
+      long startResultEndTime = System.nanoTime();
+
+      long startDuration = (startResultEndTime - startResultStartTime) / 1_000_000;
+      System.out.println("인덱스가 있는 경우 첫 페이지 실행 시간: " + startDuration + "ms");
+      withIndexTimesStart.add(startDuration);
+
+      long middleResultStartTime = System.nanoTime();
+
+      Page<GetPostListInBoardResponseDto> middleResult =
+          postQueryService.getPostListInBoard(
+              testBoard.getId(), PageRequest.of(middlePage, pageSize));
+
+      long middleResultEndTime = System.nanoTime();
+
+      long middleDuration = (middleResultEndTime - middleResultStartTime) / 1_000_000;
+      System.out.println("인덱스가 있는 경우 중간 페이지 실행 시간: " + middleDuration + "ms");
+      withIndexTimesMiddle.add(middleDuration);
+
+      long lastResultStartTime = System.nanoTime();
+
+      Page<GetPostListInBoardResponseDto> lastResult =
+          postQueryService.getPostListInBoard(
+              testBoard.getId(), PageRequest.of(lastPage, pageSize));
+
+      long lastResultEndTime = System.nanoTime();
+
+      long lastDuration = (lastResultEndTime - lastResultStartTime) / 1_000_000;
+      System.out.println("인덱스가 있는 경우 마지막 페이지 실행 시간: " + lastDuration + "ms");
+      withIndexTimesEnd.add(lastDuration);
+
+      Assertions.assertFalse(startResult.getContent().isEmpty());
+      Assertions.assertEquals(TOTAL_POSTS, startResult.getTotalElements());
+      Assertions.assertFalse(middleResult.getContent().isEmpty());
+      Assertions.assertEquals(TOTAL_POSTS, middleResult.getTotalElements());
+      Assertions.assertFalse(lastResult.getContent().isEmpty());
+      Assertions.assertEquals(TOTAL_POSTS, lastResult.getTotalElements());
+
+      double startAverage =
+          withIndexTimesStart.stream().mapToLong(Long::longValue).average().orElse(0);
+      double middleAverage =
+          withIndexTimesMiddle.stream().mapToLong(Long::longValue).average().orElse(0);
+      double lastAverage =
+          withIndexTimesEnd.stream().mapToLong(Long::longValue).average().orElse(0);
+
+      System.out.println("인덱스가 있는 경우 시작 평균 실행 시간: " + startAverage + "ms");
+      System.out.println("인덱스가 있는 경우 중간 평균 실행 시간: " + middleAverage + "ms");
+      System.out.println("인덱스가 있는 경우 마지막 평균 실행 시간: " + lastAverage + "ms");
+    }
+
+    @RepeatedTest(
+        value = REPEAT_COUNT,
+        name = "{displayName} - 반복 {currentRepetition}/{totalRepetitions}")
+    @DisplayName("인덱스가 없는 경우")
+    void getPostInBoard_Without_Index() {
+
+      transactionTemplate.executeWithoutResult(
+          status -> {
+            try {
+              entityManager
+                  .createNativeQuery("DROP INDEX idx_post_created_at_post_id ON post")
+                  .executeUpdate();
+              System.out.println("인덱스 삭제 성공");
+            } catch (Exception e) {
+              System.out.println("인덱스가 존재하지 않음, 삭제할 필요 없음");
+            }
+          });
+
+      long startResultStartTime = System.nanoTime();
+
+      Page<GetPostListInBoardResponseDto> startResult =
+          postQueryService.getPostListInBoard(testBoard.getId(), PageRequest.of(0, pageSize));
+
+      long startResultEndTime = System.nanoTime();
+
+      long startDuration = (startResultEndTime - startResultStartTime) / 1_000_000;
+      System.out.println("인덱스가 없는 경우 첫 페이지 실행 시간: " + startDuration + "ms");
+      withoutIndexTimesStart.add(startDuration);
+
+      long middleResultStartTime = System.nanoTime();
+
+      Page<GetPostListInBoardResponseDto> middleResult =
+          postQueryService.getPostListInBoard(
+              testBoard.getId(), PageRequest.of(middlePage, pageSize));
+
+      long middleResultEndTime = System.nanoTime();
+
+      long middleDuration = (middleResultEndTime - middleResultStartTime) / 1_000_000;
+      System.out.println("인덱스가 없는 경우 중간 페이지 실행 시간: " + middleDuration + "ms");
+      withoutIndexTimesMiddle.add(middleDuration);
+
+      long lastResultStartTime = System.nanoTime();
+
+      Page<GetPostListInBoardResponseDto> lastResult =
+          postQueryService.getPostListInBoard(
+              testBoard.getId(), PageRequest.of(lastPage, pageSize));
+
+      long lastResultEndTime = System.nanoTime();
+
+      long lastDuration = (lastResultEndTime - lastResultStartTime) / 1_000_000;
+      System.out.println("인덱스가 없는 경우 마지막 페이지 실행 시간: " + lastDuration + "ms");
+      withoutIndexTimesEnd.add(lastDuration);
+
+      Assertions.assertFalse(startResult.getContent().isEmpty());
+      Assertions.assertEquals(TOTAL_POSTS, startResult.getTotalElements());
+      Assertions.assertFalse(middleResult.getContent().isEmpty());
+      Assertions.assertEquals(TOTAL_POSTS, middleResult.getTotalElements());
+      Assertions.assertFalse(lastResult.getContent().isEmpty());
+      Assertions.assertEquals(TOTAL_POSTS, lastResult.getTotalElements());
+
+      transactionTemplate.executeWithoutResult(
+          status ->
+              entityManager
+                  .createNativeQuery(
+                      "CREATE INDEX idx_post_created_at_post_id ON POST (board_id, post_id DESC, created_at DESC)")
+                  .executeUpdate());
+
+      double startAverage =
+          withoutIndexTimesStart.stream().mapToLong(Long::longValue).average().orElse(0);
+      double middleAverage =
+          withoutIndexTimesMiddle.stream().mapToLong(Long::longValue).average().orElse(0);
+      double lastAverage =
+          withoutIndexTimesEnd.stream().mapToLong(Long::longValue).average().orElse(0);
+
+      System.out.println("인덱스가 없는 경우 시작 평균 실행 시간: " + startAverage + "ms");
+      System.out.println("인덱스가 없는 경우 중간 평균 실행 시간: " + middleAverage + "ms");
+      System.out.println("인덱스가 없는 경우 마지막 평균 실행 시간: " + lastAverage + "ms");
+    }
+  }
+}


### PR DESCRIPTION
# 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# ❗️ 관련 이슈 링크
Close #39 

# 📌 개요
- 게시글 조회를 구현하였습니다.
- RESTful API로 '/api/post/{boardId}'를 추가하였습니다.


## 페이징
애플리케이션 내에서 모든 데이터를 메모리로 불러온 후 특정 페이지만 추출하는 방식은 비효율적이므로, DB에서 필요한 페이지의 데이터만 바로 조회하도록 페이징을 적용하였습니다.

이를 통해 다음과 같은 이점을 얻을 수 있습니다.

- 대용량 데이터를 한 번에 조회하는 경우 발생하는 서버 및 DB 부하를 줄일 수 있음.
- 불필요한 데이터 전송을 방지하여 네트워크 부하를 감소시키고 응답 속도를 개선할 수 있음.
- 대량 데이터를 조회할 때 발생할 수 있는 DB 성능 저하 및 타임아웃 문제를 예방할 수 있음.
- 정렬(Sorting) 및 검색(Filtering) 기능과 결합하여 사용자가 원하는 데이터를 더욱 효율적으로 찾을 수 있음.

**구현 방식**
페이징 기능을 `QueryDSL`을 활용하여 구현하였으며, `Pageable` 객체를 이용해 동적으로 정렬 옵션을 적용할 수 있도록 하였습니다.

- `OrderSpecifier`를 사용하여 사용자가 요청한 정렬 기준을 동적으로 적용합니다.
- `leftJoin`을 활용하여 연관 데이터를 한 번의 쿼리로 조회함으로써 N+1 문제를 방지합니다.
- `@QueryProjection`을 사용하여 컴파일 단계에서 select 문을 검증하여 안정성을 확보합니다.

## 인덱스
대용량 데이터를 빠르게 조회하기 위해 게시글 테이블에 인덱스를 적용하였습니다.
인덱스 추가로 인해 쓰기 성능이 저하될 수 있지만, 읽기 성능 향상을 우선적으로 고려하여 적용하였습니다.
페이징 및 정렬 성능 최적화를 고려하여 게시판별 조회, 좋아요/평점 순 정렬, 최신 글 조회 등의 성능을 개선하였습니다.

** 테스트 **
200만건의 데이터를 삽입하여 10번의 실행 하였습니다.

- 인덱스가 있는 경우 실행시간
![인덱스가 있는 경우](https://github.com/user-attachments/assets/b057672f-ef9d-48f5-8984-2883f50a8537)
인덱스가 있는 경우 시작 페이지 실행시간 - 339ms
인덱스가 있는 경우 중간 페이지 실행시간 - 704ms
인덱스가 있는 경우 마지막 페이지 실행시간 - 2372ms

- 인덱스가 없는 경우 실행시간
![인덱스가 없는 경우](https://github.com/user-attachments/assets/7b593afd-aba3-4361-bb89-edb59a230bf3)
인덱스가 없는 경우 시작 페이지 실행시간 - 1672ms
인덱스가 없는 경우 중간 페이지 실행시간 - 5808ms
인덱스가 없는 경우 마지막 페이지 실행시간 - 6475ms

# 🔁 변경 사항
1. **PostController**
   - `GET /api/post/{boardId}` 엔드포인트 추가
   - SwaggerDocs 작성

2. **PostQueryService**
   - `getPostListInBoard(Long, Pageable)` 메서드 구현 : 페이지 요청 기반 게시글 조회

3. **Post**
   - 조회 관련 인덱스 추가

# 👀 기타 더 이야기해볼 점

![getPostInBoard](https://github.com/user-attachments/assets/32a19d76-428e-4602-aac9-25654763f46b)

# ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.