### PR TITLE
[Feat] : 좋아요 구현

### DIFF
--- a/src/main/java/com/example/demo/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalErrorCode.java
@@ -48,9 +48,12 @@ public enum GlobalErrorCode {
   PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "40402", "등록된 문제가 없습니다."),
   BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "40403", "등록된 게시판이 없습니다."),
   BOARD_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "40404", "등록된 게시판 사용자가 없습니다."),
+  POST_NOT_FOUND(HttpStatus.NOT_FOUND, "40405", "등록된 게시물이 없습니다."),
+  POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "40406", "게시물 좋아요가 없습니다."),
 
   // 409 Conflict
-  DUPLICATE_EMAIL(HttpStatus.CONFLICT, "40901", "이미 등록된 이메일입니다.");
+  DUPLICATE_EMAIL(HttpStatus.CONFLICT, "40901", "이미 등록된 이메일입니다."),
+  DUPLICATE_LIKE(HttpStatus.CONFLICT, "40902", "이미 좋아요가 존재합니다.");
 
   private final HttpStatus httpStatus;
   private final String divideCode;

--- a/src/main/java/com/example/demo/global/exception/custom/PostException.java
+++ b/src/main/java/com/example/demo/global/exception/custom/PostException.java
@@ -1,0 +1,10 @@
+package com.example.demo.global.exception.custom;
+
+import com.example.demo.global.exception.GlobalErrorCode;
+import com.example.demo.global.exception.GlobalException;
+
+public class PostException extends GlobalException {
+  public PostException(GlobalErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/example/demo/post/controller/PostController.java
+++ b/src/main/java/com/example/demo/post/controller/PostController.java
@@ -14,9 +14,12 @@ import com.example.demo.global.exception.GlobalErrorCode;
 import com.example.demo.global.response.BaseResponse;
 import com.example.demo.global.security.domain.MemberDetails;
 import com.example.demo.post.controller.swagger.api.CreatePostApiDocs;
+import com.example.demo.post.controller.swagger.api.CreatePostLikeApiDocs;
+import com.example.demo.post.controller.swagger.api.DeletePostLikeApiDocs;
 import com.example.demo.post.controller.swagger.api.GetPostListInBoardApiDocs;
 import com.example.demo.post.dto.CreatePostRequestDto;
 import com.example.demo.post.dto.GetPostListInBoardResponseDto;
+import com.example.demo.post.dto.PostLikeStatusResponseDto;
 import com.example.demo.post.facade.PostFacade;
 
 import lombok.RequiredArgsConstructor;
@@ -49,5 +52,31 @@ public class PostController {
         .body(
             BaseResponse.onSuccess(
                 GlobalErrorCode.OK, postFacade.getPostListInBoard(boardId, pageable)));
+  }
+
+  @PostMapping("/{boardId}/{postId}")
+  @SwaggerDocs(CreatePostLikeApiDocs.class)
+  public ResponseEntity<BaseResponse<PostLikeStatusResponseDto>> createPostLike(
+      @PathVariable(name = "boardId") Long boardId,
+      @PathVariable(name = "postId") Long postId,
+      @AuthenticationPrincipal MemberDetails memberDetails) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(
+            BaseResponse.onSuccess(
+                GlobalErrorCode.CREATED,
+                postFacade.createPostLike(boardId, memberDetails.getMember(), postId)));
+  }
+
+  @DeleteMapping("/{boardId}/{postId}")
+  @SwaggerDocs(DeletePostLikeApiDocs.class)
+  public ResponseEntity<BaseResponse<PostLikeStatusResponseDto>> deletePostLike(
+      @PathVariable(name = "boardId") Long boardId,
+      @PathVariable(name = "postId") Long postId,
+      @AuthenticationPrincipal MemberDetails memberDetails) {
+    return ResponseEntity.status(HttpStatus.NO_CONTENT)
+        .body(
+            BaseResponse.onSuccess(
+                GlobalErrorCode.DELETED,
+                postFacade.deletePostLike(boardId, memberDetails.getMember(), postId)));
   }
 }

--- a/src/main/java/com/example/demo/post/controller/swagger/PostSwaggerConst.java
+++ b/src/main/java/com/example/demo/post/controller/swagger/PostSwaggerConst.java
@@ -60,4 +60,52 @@ public class PostSwaggerConst {
                   }
                 }
                 """;
+
+  public static final String CREATE_POST_LIKE_SUCCESS =
+      """
+                  {
+                    "isSuccess": true,
+                    "code": "200",
+                    "message": "요청 성공",
+                    "divideCode": "20001",
+                    "data": {
+                      "likeStatus": true,
+                      "description": "좋아요가 추가되었습니다."
+                    }
+                  }
+            """;
+
+  public static final String CREATE_POST_LIKE_FAIL_DUPLICATE_EMAIL =
+      """
+                  {
+                    "isSuccess": false,
+                    "code": "409",
+                    "message": "이미 좋아요가 존재합니다.",
+                    "divideCode": "40902"
+                  }
+            """;
+
+  public static final String DELETE_POST_LIKE_SUCCESS =
+      """
+                  {
+                    "isSuccess": true,
+                    "code": "200",
+                    "message": "요청 성공",
+                    "divideCode": "20001",
+                    "data": {
+                      "likeStatus": false,
+                      "description": "좋아요가 삭제되었습니다."
+                    }
+                  }
+            """;
+
+  public static final String DELETE_POST_LIKE_FAIL_POST_LIKE_NOT_FOUND =
+      """
+                  {
+                    "isSuccess": false,
+                    "code": "404",
+                    "message": "게시물 좋아요가 없습니다.",
+                    "divideCode": "40406"
+                  }
+            """;
 }

--- a/src/main/java/com/example/demo/post/controller/swagger/api/CreatePostLikeApiDocs.java
+++ b/src/main/java/com/example/demo/post/controller/swagger/api/CreatePostLikeApiDocs.java
@@ -1,0 +1,40 @@
+package com.example.demo.post.controller.swagger.api;
+
+import org.springframework.http.MediaType;
+
+import com.example.demo.global.response.BaseResponse;
+import com.example.demo.post.controller.swagger.PostSwaggerConst;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public class CreatePostLikeApiDocs {
+
+  @Operation(summary = "게시글 좋아요 생성", description = "게시글 좋아요를 생성합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "201",
+            description = "게시글 좋아요 생성 성공",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BaseResponse.class),
+                    examples = @ExampleObject(value = PostSwaggerConst.CREATE_POST_LIKE_SUCCESS))),
+        @ApiResponse(
+            responseCode = "40902",
+            description = "게시판이 존재하지 않음",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BaseResponse.class),
+                    examples =
+                        @ExampleObject(
+                            value = PostSwaggerConst.CREATE_POST_LIKE_FAIL_DUPLICATE_EMAIL)))
+      })
+  public void createPostLike() {}
+}

--- a/src/main/java/com/example/demo/post/controller/swagger/api/DeletePostLikeApiDocs.java
+++ b/src/main/java/com/example/demo/post/controller/swagger/api/DeletePostLikeApiDocs.java
@@ -1,0 +1,40 @@
+package com.example.demo.post.controller.swagger.api;
+
+import org.springframework.http.MediaType;
+
+import com.example.demo.global.response.BaseResponse;
+import com.example.demo.post.controller.swagger.PostSwaggerConst;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public class DeletePostLikeApiDocs {
+
+  @Operation(summary = "게시글 좋아요 삭제", description = "게시글 좋아요를 삭제합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "게시글 좋아요 삭제 성공",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BaseResponse.class),
+                    examples = @ExampleObject(value = PostSwaggerConst.DELETE_POST_LIKE_SUCCESS))),
+        @ApiResponse(
+            responseCode = "40406",
+            description = "게시판이 존재하지 않음",
+            content =
+                @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BaseResponse.class),
+                    examples =
+                        @ExampleObject(
+                            value = PostSwaggerConst.DELETE_POST_LIKE_FAIL_POST_LIKE_NOT_FOUND)))
+      })
+  public void deletePostLike() {}
+}

--- a/src/main/java/com/example/demo/post/controller/swagger/api/GetPostListInBoardApiDocs.java
+++ b/src/main/java/com/example/demo/post/controller/swagger/api/GetPostListInBoardApiDocs.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 public class GetPostListInBoardApiDocs {
-  @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
+  @Operation(summary = "게시글 페이지 조회", description = "게시글을 페이지로 조회합니다.")
   @ApiResponses(
       value = {
         @ApiResponse(

--- a/src/main/java/com/example/demo/post/dto/PostLikeStatusResponseDto.java
+++ b/src/main/java/com/example/demo/post/dto/PostLikeStatusResponseDto.java
@@ -1,0 +1,3 @@
+package com.example.demo.post.dto;
+
+public record PostLikeStatusResponseDto(Boolean likeStatus, String description) {}

--- a/src/main/java/com/example/demo/post/entity/Post.java
+++ b/src/main/java/com/example/demo/post/entity/Post.java
@@ -34,7 +34,6 @@ public class Post {
 
   @Setter @Embedded private PostCode postCode;
 
-  @Setter
   @Column(name = "like_count", nullable = false)
   @Builder.Default
   private Integer likeCount = 0;
@@ -54,4 +53,14 @@ public class Post {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "board_member_id")
   private BoardMember boardMember;
+
+  public void increaseLikeCount() {
+    this.likeCount++;
+  }
+
+  public void decreaseLikeCount() {
+    if (this.likeCount > 0) {
+      this.likeCount--;
+    }
+  }
 }

--- a/src/main/java/com/example/demo/post/entity/PostLike.java
+++ b/src/main/java/com/example/demo/post/entity/PostLike.java
@@ -9,7 +9,13 @@ import com.example.demo.board.entity.BoardMember;
 import lombok.*;
 
 @Entity
-@Table(name = "post_like")
+@Table(
+    name = "post_like",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_post_like_post_board_member",
+          columnNames = {"post_id", "board_member_id"})
+    })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/demo/post/entity/repository/PostJpaRepository.java
+++ b/src/main/java/com/example/demo/post/entity/repository/PostJpaRepository.java
@@ -1,7 +1,19 @@
 package com.example.demo.post.entity.repository;
 
+import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.demo.post.entity.Post;
 
-public interface PostJpaRepository extends JpaRepository<Post, Long> {}
+public interface PostJpaRepository extends JpaRepository<Post, Long> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(value = "SELECT p FROM Post p WHERE p.id = :id")
+  Optional<Post> findByIdWithPessimisticLock(@Param("id") Long id);
+}

--- a/src/main/java/com/example/demo/post/entity/repository/PostLikeJpaRepository.java
+++ b/src/main/java/com/example/demo/post/entity/repository/PostLikeJpaRepository.java
@@ -1,0 +1,15 @@
+package com.example.demo.post.entity.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.demo.board.entity.BoardMember;
+import com.example.demo.post.entity.Post;
+import com.example.demo.post.entity.PostLike;
+
+public interface PostLikeJpaRepository extends JpaRepository<PostLike, Long> {
+  Optional<PostLike> findPostLikeByPostAndBoardMember(Post post, BoardMember boardMember);
+
+  Boolean existsByPostAndBoardMember(Post post, BoardMember boardMember);
+}

--- a/src/main/java/com/example/demo/post/facade/PostFacade.java
+++ b/src/main/java/com/example/demo/post/facade/PostFacade.java
@@ -8,10 +8,17 @@ import com.example.demo.board.entity.Board;
 import com.example.demo.board.entity.BoardMember;
 import com.example.demo.board.service.query.BoardMemberQueryService;
 import com.example.demo.board.service.query.BoardQueryService;
+import com.example.demo.global.exception.GlobalErrorCode;
+import com.example.demo.global.exception.custom.PostException;
 import com.example.demo.member.entity.Member;
 import com.example.demo.post.dto.CreatePostRequestDto;
 import com.example.demo.post.dto.GetPostListInBoardResponseDto;
+import com.example.demo.post.dto.PostLikeStatusResponseDto;
+import com.example.demo.post.entity.Post;
+import com.example.demo.post.entity.PostLike;
 import com.example.demo.post.service.PostCommandService;
+import com.example.demo.post.service.PostLikeCommandService;
+import com.example.demo.post.service.PostLikeQueryService;
 import com.example.demo.post.service.PostQueryService;
 
 import lombok.RequiredArgsConstructor;
@@ -22,6 +29,8 @@ public class PostFacade {
 
   private final PostCommandService postCommandService;
   private final PostQueryService postQueryService;
+  private final PostLikeCommandService postLikeCommandService;
+  private final PostLikeQueryService postLikeQueryService;
 
   private final BoardQueryService boardQueryService;
   private final BoardMemberQueryService boardMemberQueryService;
@@ -51,5 +60,49 @@ public class PostFacade {
    */
   public Page<GetPostListInBoardResponseDto> getPostListInBoard(Long boardId, Pageable pageable) {
     return postQueryService.getPostListInBoard(boardId, pageable);
+  }
+
+  /**
+   * 주어진 게시판 ID와 회원, 게시글 ID를 통해 게시글 좋아요를 생성합니다.
+   *
+   * @param boardId 게시글이 있는 게시판 ID
+   * @param member 해당 {@link Member} 회원
+   * @param postId 좋아요 할 게시글 ID
+   * @return 게시글 좋아요 상태 {@link PostLikeStatusResponseDto} (좋아요 상태, 설명)
+   */
+  public PostLikeStatusResponseDto createPostLike(Long boardId, Member member, Long postId) {
+    Board board = boardQueryService.getBoardById(boardId);
+
+    BoardMember boardMember = boardMemberQueryService.getBoardMemberByBoardAndMember(board, member);
+
+    Post post = postQueryService.getPostById(postId);
+
+    if (postLikeQueryService.existsPostLike(post, boardMember)) {
+      throw new PostException(GlobalErrorCode.DUPLICATE_LIKE);
+    }
+
+    return new PostLikeStatusResponseDto(
+        postLikeCommandService.createPostLike(post, boardMember), "좋아요가 추가되었습니다.");
+  }
+
+  /**
+   * 주어진 게시판 ID와 회원, 게시글 ID를 통해 게시글 좋아요를 삭제합니다.
+   *
+   * @param boardId 게시글이 있는 게시판 ID
+   * @param member 해당 {@link Member} 회원
+   * @param postId 좋아요 삭제 할 게시글 ID
+   * @return 게시글 좋아요 상태 {@link PostLikeStatusResponseDto} (좋아요 상태, 설명)
+   */
+  public PostLikeStatusResponseDto deletePostLike(Long boardId, Member member, Long postId) {
+    Board board = boardQueryService.getBoardById(boardId);
+
+    BoardMember boardMember = boardMemberQueryService.getBoardMemberByBoardAndMember(board, member);
+
+    Post post = postQueryService.getPostById(postId);
+
+    PostLike postLike = postLikeQueryService.getPostLike(post, boardMember);
+
+    return new PostLikeStatusResponseDto(
+        postLikeCommandService.deletePostLike(postLike), "좋아요가 삭제되었습니다.");
   }
 }

--- a/src/main/java/com/example/demo/post/service/PostLikeCommandService.java
+++ b/src/main/java/com/example/demo/post/service/PostLikeCommandService.java
@@ -1,0 +1,52 @@
+package com.example.demo.post.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.demo.board.entity.BoardMember;
+import com.example.demo.post.entity.Post;
+import com.example.demo.post.entity.PostLike;
+import com.example.demo.post.entity.repository.PostLikeJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostLikeCommandService {
+
+  private final PostLikeJpaRepository postLikeJpaRepository;
+
+  /**
+   * 게시글과 게시글 회원을 통해 게시글 좋아요를 생성합니다.
+   *
+   * @param post 주어진 {@link Post} 게시글
+   * @param boardMember 주어진 {@link BoardMember} 게시판 회원
+   * @return true 게시판 좋아요 상태 (true = 좋아요 누름)
+   */
+  public Boolean createPostLike(Post post, BoardMember boardMember) {
+    PostLike postLike =
+        PostLike.builder()
+            .post(post)
+            .boardMember(boardMember)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    postLikeJpaRepository.save(postLike);
+
+    return true;
+  }
+
+  /**
+   * 게시글 좋아요를 삭제합니다.
+   *
+   * @param postLike 주어진 {@link PostLike} 게시글 좋아요
+   * @return false 게시글 좋아요 취소 (false = 좋아요 취소/안누름)
+   */
+  public Boolean deletePostLike(PostLike postLike) {
+    postLikeJpaRepository.delete(postLike);
+    return false;
+  }
+}

--- a/src/main/java/com/example/demo/post/service/PostLikeQueryService.java
+++ b/src/main/java/com/example/demo/post/service/PostLikeQueryService.java
@@ -1,0 +1,46 @@
+package com.example.demo.post.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.board.entity.BoardMember;
+import com.example.demo.global.annotation.ReadOnlyTransactional;
+import com.example.demo.global.exception.GlobalErrorCode;
+import com.example.demo.global.exception.custom.PostException;
+import com.example.demo.post.entity.Post;
+import com.example.demo.post.entity.PostLike;
+import com.example.demo.post.entity.repository.PostLikeJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@ReadOnlyTransactional
+public class PostLikeQueryService {
+
+  private final PostLikeJpaRepository postLikeJpaRepository;
+
+  /**
+   * 주어진 게시글, 게시판 회원을 통해 게시글 좋아요를 조회합니다.
+   *
+   * @param post 주어진 {@link Post} 게시글
+   * @param boardMember 주어진 {@link BoardMember} 게시판 회원
+   * @return 조회된 {@link PostLike} 게시글 좋아요
+   * @throws PostException {@code GlobalErrorCode.POST_LIKE_NOT_FOUND} - 해당 게시글 좋아요가 없는 경우
+   */
+  public PostLike getPostLike(Post post, BoardMember boardMember) {
+    return postLikeJpaRepository
+        .findPostLikeByPostAndBoardMember(post, boardMember)
+        .orElseThrow(() -> new PostException(GlobalErrorCode.POST_LIKE_NOT_FOUND));
+  }
+
+  /**
+   * 주어진 게시글, 게시판 회원을 통해 게시글 좋아요가 존재 유무를 반환합니다.
+   *
+   * @param post 주어진 {@link Post} 게시글
+   * @param boardMember 주어진 {@link BoardMember} 게시판 회원
+   * @return 게시글 좋아요 존재 유무
+   */
+  public boolean existsPostLike(Post post, BoardMember boardMember) {
+    return postLikeJpaRepository.existsByPostAndBoardMember(post, boardMember);
+  }
+}

--- a/src/main/java/com/example/demo/post/service/PostQueryService.java
+++ b/src/main/java/com/example/demo/post/service/PostQueryService.java
@@ -3,6 +3,7 @@ package com.example.demo.post.service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.demo.global.annotation.ReadOnlyTransactional;
 import com.example.demo.global.exception.GlobalErrorCode;
@@ -43,6 +44,20 @@ public class PostQueryService {
   public Post getPostById(Long postId) {
     return postJpaRepository
         .findById(postId)
+        .orElseThrow(() -> new PostException(GlobalErrorCode.POST_NOT_FOUND));
+  }
+
+  /**
+   * 주어진 게시글 ID를 통해 해당 게시글을 반환합니다. (비관적 락 적용)
+   *
+   * @param postId 조회할 게시글 ID
+   * @return 조회된 {@link Post} 게시글
+   * @throws PostException {@code GlobalErrorCode.POST_NOT_FOUND} - 헤당 게시글이 없는 경우
+   */
+  @Transactional
+  public Post getPostByIdWithPessimisticLock(Long postId) {
+    return postJpaRepository
+        .findByIdWithPessimisticLock(postId)
         .orElseThrow(() -> new PostException(GlobalErrorCode.POST_NOT_FOUND));
   }
 }

--- a/src/main/java/com/example/demo/post/service/PostQueryService.java
+++ b/src/main/java/com/example/demo/post/service/PostQueryService.java
@@ -5,7 +5,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.example.demo.global.annotation.ReadOnlyTransactional;
+import com.example.demo.global.exception.GlobalErrorCode;
+import com.example.demo.global.exception.custom.PostException;
 import com.example.demo.post.dto.GetPostListInBoardResponseDto;
+import com.example.demo.post.entity.Post;
+import com.example.demo.post.entity.repository.PostJpaRepository;
 import com.example.demo.post.entity.repository.PostQueryDslRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -15,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @ReadOnlyTransactional
 public class PostQueryService {
 
+  private final PostJpaRepository postJpaRepository;
   private final PostQueryDslRepository postQueryDslRepository;
 
   /**
@@ -26,5 +31,18 @@ public class PostQueryService {
    */
   public Page<GetPostListInBoardResponseDto> getPostListInBoard(Long boardId, Pageable pageable) {
     return postQueryDslRepository.findPostListByBoard(boardId, pageable);
+  }
+
+  /**
+   * 주어진 게시글 ID를 통해 해당 게시글을 반환합니다.
+   *
+   * @param postId 조회할 게시글 ID
+   * @return 조회된 {@link Post} 게시글
+   * @throws PostException {@code GlobalErrorCode.POST_NOT_FOUND} - 헤당 게시글이 없는 경우
+   */
+  public Post getPostById(Long postId) {
+    return postJpaRepository
+        .findById(postId)
+        .orElseThrow(() -> new PostException(GlobalErrorCode.POST_NOT_FOUND));
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
       settings:
         web-allow-others: true
   datasource:
-    url: jdbc:h2:mem:test;CACHE_SIZE=131072
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;LOCK_MODE=0
     driver-class-name: org.h2.Driver
     username: test
     password: test
@@ -29,10 +29,15 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        show_sql: true
   sql:
     init:
       mode: always
       schema-locations: classpath:schema-h2.sql
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.engine.transaction: DEBUG
 
 ---
 #actuator

--- a/src/test/java/com/example/demo/post/PostLikeCommandServiceTest.java
+++ b/src/test/java/com/example/demo/post/PostLikeCommandServiceTest.java
@@ -1,0 +1,79 @@
+package com.example.demo.post;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.demo.board.entity.BoardMember;
+import com.example.demo.post.entity.Post;
+import com.example.demo.post.entity.PostLike;
+import com.example.demo.post.entity.repository.PostLikeJpaRepository;
+import com.example.demo.post.service.PostLikeCommandService;
+
+@ExtendWith(MockitoExtension.class)
+public class PostLikeCommandServiceTest {
+
+  @Mock private PostLikeJpaRepository postLikeJpaRepository;
+
+  @InjectMocks private PostLikeCommandService postLikeCommandService;
+
+  @Nested
+  @DisplayName("게시물 좋아요를 생성할 때")
+  class createPostLike {
+    @Test
+    @DisplayName("게시물 좋아요를 생성하고 true를 반환합니다.")
+    void createPostLike_Success() {
+      // give
+      Post mockPost = mock(Post.class);
+      BoardMember mockBoardMember = mock(BoardMember.class);
+
+      PostLike testPostLike =
+          PostLike.builder().post(mockPost).boardMember(mockBoardMember).build();
+
+      when(postLikeJpaRepository.save(any(PostLike.class))).thenReturn(testPostLike);
+
+      // when
+      Boolean result = postLikeCommandService.createPostLike(mockPost, mockBoardMember);
+
+      // then
+      ArgumentCaptor<PostLike> captor = ArgumentCaptor.forClass(PostLike.class);
+      verify(postLikeJpaRepository, times(1)).save(captor.capture());
+
+      PostLike postLike = captor.getValue();
+      assertTrue(result, "true가 일치해야합니다.");
+      assertEquals(mockPost, postLike.getPost(), "게시글이 일치해야합니다.");
+      assertEquals(mockBoardMember, postLike.getBoardMember(), "게시판 회원이 일치해야합니다.");
+    }
+  }
+
+  @Nested
+  @DisplayName("게시글 좋아요를 삭제할 때")
+  class deletePostLike {
+    @Test
+    @DisplayName("게시글 좋아요를 삭제하고 false를 반환합니다.")
+    void deletePostLike_Success() {
+      // give
+      Post mockPost = mock(Post.class);
+      BoardMember mockBoardMember = mock(BoardMember.class);
+
+      PostLike testPostLike =
+          PostLike.builder().post(mockPost).boardMember(mockBoardMember).build();
+
+      // when
+      Boolean result = postLikeCommandService.deletePostLike(testPostLike);
+
+      // then
+      assertFalse(result, "false가 일치해야합니다.");
+      verify(postLikeJpaRepository, times(1)).delete(testPostLike);
+    }
+  }
+}

--- a/src/test/java/com/example/demo/post/PostLikeQueryServiceTest.java
+++ b/src/test/java/com/example/demo/post/PostLikeQueryServiceTest.java
@@ -1,0 +1,123 @@
+package com.example.demo.post;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.demo.board.entity.BoardMember;
+import com.example.demo.global.exception.GlobalErrorCode;
+import com.example.demo.global.exception.custom.PostException;
+import com.example.demo.post.entity.Post;
+import com.example.demo.post.entity.PostLike;
+import com.example.demo.post.entity.repository.PostLikeJpaRepository;
+import com.example.demo.post.service.PostLikeQueryService;
+
+@ExtendWith(MockitoExtension.class)
+public class PostLikeQueryServiceTest {
+
+  @Mock private PostLikeJpaRepository postLikeJpaRepository;
+
+  @InjectMocks private PostLikeQueryService postLikeQueryService;
+
+  @Nested
+  @DisplayName("게시글 좋아요를 조회할 때")
+  class getPostLike {
+    @Test
+    @DisplayName("게시글 좋아요를 반환합니다.")
+    void getPostLike_Success() {
+      // give
+      Post mockPost = mock(Post.class);
+      BoardMember mockBoardMember = mock(BoardMember.class);
+
+      PostLike testPostLike =
+          PostLike.builder().post(mockPost).boardMember(mockBoardMember).build();
+
+      when(postLikeJpaRepository.findPostLikeByPostAndBoardMember(mockPost, mockBoardMember))
+          .thenReturn(Optional.of(testPostLike));
+
+      // when
+      PostLike result = postLikeQueryService.getPostLike(mockPost, mockBoardMember);
+
+      // then
+      assertNotNull(result, "조회 결과가 null이면 안됩니다.");
+      assertEquals(mockPost, result.getPost(), "게시글이 일치해야합니다.");
+      assertEquals(mockBoardMember, result.getBoardMember(), "게시판 회원이 일치해야합니다.");
+      verify(postLikeJpaRepository, times(1))
+          .findPostLikeByPostAndBoardMember(mockPost, mockBoardMember);
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요가 존재하지 않으면 예외를 발생시킵니다.")
+    void getPostLike_Fail_Post_Like_Not_Found() {
+      // give
+      Post mockPost = mock(Post.class);
+      BoardMember mockBoardMember = mock(BoardMember.class);
+
+      PostLike testPostLike =
+          PostLike.builder().post(mockPost).boardMember(mockBoardMember).build();
+
+      when(postLikeJpaRepository.findPostLikeByPostAndBoardMember(mockPost, mockBoardMember))
+          .thenReturn(Optional.empty());
+
+      // when
+      PostException result =
+          assertThrows(
+              PostException.class,
+              () -> postLikeQueryService.getPostLike(mockPost, mockBoardMember));
+
+      // then
+      assertEquals(GlobalErrorCode.POST_LIKE_NOT_FOUND, result.getErrorCode(), "예외코드가 일치해야합니다.");
+      verify(postLikeJpaRepository, times(1))
+          .findPostLikeByPostAndBoardMember(mockPost, mockBoardMember);
+    }
+  }
+
+  @Nested
+  @DisplayName("게시글 좋아요가 존재하는지 조회할 때")
+  class existsPostLike {
+    @Test
+    @DisplayName("존재하면 true를 반환합니다.")
+    void existsPostLike_Return_True() {
+      // give
+      Post mockPost = mock(Post.class);
+      BoardMember mockBoardMember = mock(BoardMember.class);
+
+      when(postLikeJpaRepository.existsByPostAndBoardMember(mockPost, mockBoardMember))
+          .thenReturn(true);
+
+      // when
+      boolean result = postLikeQueryService.existsPostLike(mockPost, mockBoardMember);
+
+      // then
+      assertTrue(result, "존재하면 true를 반환해야합니다.");
+      verify(postLikeJpaRepository, times(1)).existsByPostAndBoardMember(mockPost, mockBoardMember);
+    }
+
+    @Test
+    @DisplayName("존재하지 않으면 false를 반환합니다.")
+    void existsPostLike_Return_False() {
+      // give
+      Post mockPost = mock(Post.class);
+      BoardMember mockBoardMember = mock(BoardMember.class);
+
+      when(postLikeJpaRepository.existsByPostAndBoardMember(mockPost, mockBoardMember))
+          .thenReturn(false);
+
+      // when
+      Boolean result = postLikeQueryService.existsPostLike(mockPost, mockBoardMember);
+
+      // then
+      assertFalse(result, "존재하지 않으면 false를 반환해야합니다.");
+      verify(postLikeJpaRepository, times(1)).existsByPostAndBoardMember(mockPost, mockBoardMember);
+    }
+  }
+}

--- a/src/test/java/com/example/demo/post/performance/PostLikeSynchronicityTest.java
+++ b/src/test/java/com/example/demo/post/performance/PostLikeSynchronicityTest.java
@@ -1,0 +1,128 @@
+package com.example.demo.post.performance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.example.demo.board.entity.Board;
+import com.example.demo.board.entity.BoardMember;
+import com.example.demo.board.entity.repository.BoardMemberRepository;
+import com.example.demo.board.entity.repository.BoardRepository;
+import com.example.demo.member.entity.Member;
+import com.example.demo.member.entity.MemberRole;
+import com.example.demo.member.entity.Password;
+import com.example.demo.member.entity.Tier;
+import com.example.demo.member.entity.repository.MemberRepository;
+import com.example.demo.post.entity.CodeLanguage;
+import com.example.demo.post.entity.Post;
+import com.example.demo.post.entity.PostCode;
+import com.example.demo.post.entity.repository.PostJpaRepository;
+import com.example.demo.post.entity.repository.PostLikeJpaRepository;
+import com.example.demo.post.facade.PostFacade;
+
+@SpringBootTest
+public class PostLikeSynchronicityTest {
+
+  @Autowired private PostFacade postFacade;
+  @Autowired private PostJpaRepository postJpaRepository;
+  @Autowired private PostLikeJpaRepository postLikeJpaRepository;
+  @Autowired private BoardRepository boardJpaRepository;
+  @Autowired private BoardMemberRepository boardMemberJpaRepository;
+  @Autowired private MemberRepository memberJpaRepository;
+
+  private Board testBoard;
+  private Member testMember;
+  private BoardMember testBoardMember;
+  private Post testPost;
+
+  @BeforeEach
+  void setUp() {
+    testMember =
+        memberJpaRepository.save(
+            Member.builder()
+                .email("testEmail")
+                .password(new Password("Test1234!@#$"))
+                .nickname("testNickname")
+                .profileImage("testProfileImage")
+                .identifiedCode("test")
+                .memberRole(MemberRole.USER)
+                .refreshToken("testRefreshToken")
+                .tier(Tier.UNRANK)
+                .build());
+
+    testBoard =
+        boardJpaRepository.save(
+            Board.builder().name("testName").thumbnailImage("defaultThumbnailImage").build());
+
+    testBoardMember =
+        boardMemberJpaRepository.save(
+            BoardMember.builder().board(testBoard).member(testMember).isLeader(true).build());
+
+    PostCode testPostCode = PostCode.builder().language(CodeLanguage.C).content("content").build();
+
+    testPost =
+        postJpaRepository.save(
+            Post.builder()
+                .title("testTitle")
+                .postCode(testPostCode)
+                .board(testBoard)
+                .boardMember(testBoardMember)
+                .build());
+  }
+
+  @Test
+  @DisplayName("동시에 여러 스레드가 좋아요를 실행하면 likeCount와 PostLike 수가 일치한다.")
+  void ConcurrentCreatePostLike() throws InterruptedException {
+    int threadCount = 10; // 10개 스레드로 테스트
+    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch latch = new CountDownLatch(threadCount);
+
+    for (int i = 0; i < threadCount; i++) {
+      Member member =
+          memberJpaRepository.save(
+              Member.builder()
+                  .email("testEmail" + i)
+                  .password(new Password("Test1234!@#$"))
+                  .nickname("testNickname")
+                  .profileImage("testProfileImage")
+                  .identifiedCode("test" + i)
+                  .memberRole(MemberRole.USER)
+                  .refreshToken("testRefreshToken")
+                  .tier(Tier.UNRANK)
+                  .build());
+
+      BoardMember boardMember =
+          boardMemberJpaRepository.save(
+              BoardMember.builder().board(testBoard).member(member).isLeader(true).build());
+
+      executorService.submit(
+          () -> {
+            try {
+              postFacade.createPostLike(testBoard.getId(), member, testPost.getId());
+            } catch (Exception e) {
+              System.out.println("Thread failed to create post like" + e);
+            } finally {
+              latch.countDown();
+            }
+          });
+    }
+
+    // 모든 스레드 작업 완료 대기
+    latch.await(5, TimeUnit.SECONDS);
+    executorService.shutdown();
+
+    // 결과 검증
+    Post updatedPost = postJpaRepository.findById(testPost.getId()).orElseThrow();
+
+    assertEquals(threadCount, updatedPost.getLikeCount(), "likeCount가 스레드 수와 일치해야 함");
+  }
+}


### PR DESCRIPTION
# 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# ❗️ 관련 이슈 링크
Close #41 

# 📌 개요
- 좋아요 생성/삭제와 함께 게시글의 좋아요 수를 관리하는 로직을 구현하였습니다.
- RESTful API로 '/api/post/{boardId}/{postId}' 를 추가하였습니다.

## 좋아요의 동시성
좋아요 생성/삭제 기능은 게시글이나 추후 개발 예정인 댓글 관련 API에 비해 상대적으로 트래픽이 적을 것으로 예상됩니다. 이를 바탕으로 동시성 처리 방식으로 다음 세 가지를 고민하였습니다.

- 비관적 락
- 낙관적 락
- 비동기 순차 처리

각 방식의 특성과 현재 상황을 고려해 동시성 처리 방식을 선택했습니다.

1. **비동기 순차 처리**
 비동기 순차 처리는 작업을 큐나 메시지 브로커를 통해 순차적으로 처리하는 방식입니다.
- 큐 시스템 도입 시 추가적인 인프라와 이를 관리하기 위한 설정 및 모니터링 비용이 발생하기에 좋아요를 위한 단일 작업에는 과도한 비용이 든다고 판단했습니다.

2. **낙관적 락**
 낙관적 락은 데이터 충돌이 드물다고 가정하고, 버전을 사용해 업데이트 시 충돌을 감지한 뒤 재시도하거나 예외를 처리하는 방식입니다.
- 충돌이 발생 했을 때 애플리케이션에서 재시도 로직을 구현해야 하기 때문에 코드 복잡성을 증가시키고. 트래픽이 적더라도 충돌 빈도가 낮지 않을 경우 성능 저하를 유발시킵니다.
- @Version을 엔티티에 추가해야하며, 이를 반영/관리하는 비용이 발생합니다.

3. **비관적 락**
 비관적 락은 데이터 접근 시 락을 걸어 다른 트랜잭션이 해당 데이터를 수정하지 못하도록 보장하는 방식입니다.
- 좋아요는 게시글이나 댓글 API에 비해 트래픽이 적고 단일 게시글에 대한 동시 쓰기 요청이 급격하게 증가할 가능성이 낮다고 생각하였습니다. 따라서 락 상태가 짧아 데드락이나 병목 위험이 적을 것으로 판단하였습니다.
- 추가적인 인프라나 복잡한 로직 없이 JPA의 @Lock과 트랜잭션으로 동시성을 보장할 수 있어 선택하게 되었습니다.

@ㅆ 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# ❗️ 관련 이슈 링크
Close #41 

# 📌 개요
- 좋아요 생성/삭제와 함께 게시글의 좋아요 수를 관리하는 로직을 구현하였습니다.
- RESTful API로 '/api/post/{boardId}/{postId}' 를 추가하였습니다.

## 좋아요의 동시성
좋아요 생성/삭제 기능은 게시글이나 추후 개발 예정인 댓글 관련 API에 비해 상대적으로 트래픽이 적을 것으로 예상됩니다. 이를 바탕으로 동시성 처리 방식으로 다음 세 가지를 검토했습니다:

비관적 락 (Pessimistic Lock)
낙관적 락 (Optimistic Lock)
비동기 순차 처리 (Asynchronous Sequential Processing)

각 방식의 특성과 현재 상황을 고려해 동시성 처리 방식을 선택했습니다.

1. **비동기 순차 처리**
 비동기 순차 처리는 작업을 큐나 메시지 브로커를 통해 순차적으로 처리하는 방식입니다.
- 큐 시스템 도입 시 추가적인 인프라와 이를 관리하기 위한 설정 및 모니터링 비용이 발생하기에 좋아요를 위한 단일 작업에는 과도한 비용이 든다고 판단했습니다.

2. **낙관적 락**
 낙관적 락은 데이터 충돌이 드물다고 가정하고, 버전을 사용해 업데이트 시 충돌을 감지한 뒤 재시도하거나 예외를 처리하는 방식입니다.
- 충돌이 발생 했을 때 애플리케이션에서 재시도 로직을 구현해야 하기 때문에 코드 복잡성을 증가시키고. 트래픽이 적더라도 충돌 빈도가 낮지 않을 경우 성능 저하를 유발시킵니다.
- @Version을 엔티티에 추가해야하며, 이를 반영/관리하는 비용이 발생합니다.

3. **비관적 락**
 비관적 락은 데이터 접근 시 락을 걸어 다른 트랜잭션이 해당 데이터를 수정하지 못하도록 보장하는 방식입니다.
- 좋아요는 게시글이나 댓글 API에 비해 트래픽이 적고 단일 게시글에 대한 동시 쓰기 요청이 급격하게 증가할 가능성이 낮다고 생각하였습니다. 따라서 락 상태가 짧아 데드락이나 병목 위험이 적을 것으로 판단하였습니다.
- 추가적인 인프라나 복잡한 로직 없이 JPA의 @Lock과 트랜잭션으로 동시성을 보장할 수 있어 선택하게 되었습니다.

- 10개의 스레드 동시 요청 테스트
![비관적락 테스트](https://github.com/user-attachments/assets/ccedb0d9-39b3-45f9-81d5-7af3e92313f8)



# 🔁 변경 사항
1. **PostController**
   - `POST /api/post/{boardId}/{postId}` 메서드 구현 : 게시글 좋아요 생성
   - `DELETE /api/post/{boardId}/{postId}` 메서드 구현 : 게시글 좋아요 삭제
   - SwaggerDocs 작성

2. **PostFacade**
   - `createPostLike(Long, Member, Long)` 메서드 구현 : 게시글 좋아요 생성
   - `deletePostLike(Long, Member, Long)` 메서드 구현 : 게시글 좋아요 생성

# 👀 기타 더 이야기해볼 점

![getPostById](https://github.com/user-attachments/assets/2d70f4c8-4094-45b6-be03-6b6341501bfa)
![PostLikeCommandService](https://github.com/user-attachments/assets/c0b9e756-4995-4dcf-9186-e9ccb70182c7)
![postLikeQueryService](https://github.com/user-attachments/assets/596d5439-7d2c-4430-b4d7-f69faa4a2ee0)


# ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.